### PR TITLE
Manifest fix - 

### DIFF
--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -62,16 +62,8 @@ func setManifestDesc(ep dir.ITargetArtifacts, targetPathGetter dir.ITargetPath, 
 			return errors.Wrapf(err,
 				"failed to generate the manifest file when getting the %s module content type", mod.Name)
 		}
-		modulePath := getModulePath(mod, targetPathGetter)
-		if modulePath != "" {
-			moduleEntry := entry{
-				EntryName:   mod.Name,
-				EntryPath:   modulePath,
-				ContentType: contentType,
-				EntryType:   moduleEntry,
-			}
-			entries = append(entries, moduleEntry)
-		}
+
+		entries = addModuleEntry(targetPathGetter, entries, mod, contentType)
 
 		if onlyModules {
 			continue
@@ -96,6 +88,21 @@ func setManifestDesc(ep dir.ITargetArtifacts, targetPathGetter dir.ITargetPath, 
 	}
 
 	return genManifest(ep.GetManifestPath(), entries)
+}
+
+func addModuleEntry(targetPathGetter dir.ITargetPath, entries []entry, module *mta.Module, contentType string) []entry {
+	result := entries
+	modulePath := getModulePath(module, targetPathGetter)
+	if modulePath != "" {
+		moduleEntry := entry{
+			EntryName:   module.Name,
+			EntryPath:   modulePath,
+			ContentType: contentType,
+			EntryType:   moduleEntry,
+		}
+		result = append(entries, moduleEntry)
+	}
+	return result
 }
 
 func getResourcesEntries(targetPathGetter dir.ITargetPath, resources []*mta.Resource,

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -62,13 +62,16 @@ func setManifestDesc(ep dir.ITargetArtifacts, targetPathGetter dir.ITargetPath, 
 			return errors.Wrapf(err,
 				"failed to generate the manifest file when getting the %s module content type", mod.Name)
 		}
-		moduleEntry := entry{
-			EntryName:   mod.Name,
-			EntryPath:   getModulePath(mod, targetPathGetter),
-			ContentType: contentType,
-			EntryType:   moduleEntry,
+		modulePath := getModulePath(mod, targetPathGetter)
+		if modulePath != "" {
+			moduleEntry := entry{
+				EntryName:   mod.Name,
+				EntryPath:   modulePath,
+				ContentType: contentType,
+				EntryType:   moduleEntry,
+			}
+			entries = append(entries, moduleEntry)
 		}
-		entries = append(entries, moduleEntry)
 
 		if onlyModules {
 			continue

--- a/internal/artifacts/manifest_test.go
+++ b/internal/artifacts/manifest_test.go
@@ -45,6 +45,18 @@ var _ = Describe("manifest", func() {
 			fmt.Println(golden)
 			Ω(actual).Should(Equal(golden))
 		})
+		It("Sanity - no paths", func() {
+			os.Mkdir(getTestPath("result", "mta", "node-js"), os.ModePerm)
+			loc := dir.Loc{SourcePath: getTestPath("mta"), TargetPath: getResultPath(), MtaFilename: "mta_no_paths.yaml"}
+			mtaObj, err := loc.ParseFile()
+			Ω(err).Should(Succeed())
+			Ω(setManifestDesc(&loc, &loc, mtaObj.Modules, []*mta.Resource{}, []string{}, false)).Should(Succeed())
+			actual := getFileContent(getTestPath("result", "mta", "META-INF", "MANIFEST.MF"))
+			golden := getFileContent(getTestPath("golden_assembly_manifest_no_paths.mf"))
+			fmt.Println(actual)
+			fmt.Println(golden)
+			Ω(actual).Should(Equal(golden))
+		})
 		It("With resources", func() {
 			os.MkdirAll(getTestPath("result", "assembly-sample", "META-INF"), os.ModePerm)
 			os.MkdirAll(getTestPath("result", "assembly-sample", "web"), os.ModePerm)
@@ -56,6 +68,8 @@ var _ = Describe("manifest", func() {
 			Ω(setManifestDesc(&loc, &loc, mtaObj.Modules, mtaObj.Resources, []string{}, false)).Should(Succeed())
 			actual := getFileContent(getTestPath("result", "assembly-sample", "META-INF", "MANIFEST.MF"))
 			golden := getFileContent(getTestPath("golden_assembly_manifest.mf"))
+			fmt.Println(actual)
+			fmt.Println(golden)
 			Ω(actual).Should(Equal(golden))
 		})
 		It("With missing module path", func() {

--- a/internal/artifacts/testdata/golden_assembly_manifest.mf
+++ b/internal/artifacts/testdata/golden_assembly_manifest.mf
@@ -5,12 +5,6 @@ Name: web/
 MTA-Module: java-hello-world
 Content-Type: text/directory
 
-
-Name: 
-MTA-Module: java-hello-world-backend
-Content-Type: text/directory
-
-
 Name: config-site-host.json
 MTA-Requires: java-hello-world-backend/java-site-host
 Content-Type: application/json

--- a/internal/artifacts/testdata/golden_assembly_manifest_no_paths.mf
+++ b/internal/artifacts/testdata/golden_assembly_manifest_no_paths.mf
@@ -1,0 +1,6 @@
+manifest-Version: 1.0
+Created-By: SAP Application Archive Builder 0.0.1
+
+Name: META-INF/mtad.yaml
+Content-Type: text/plain
+

--- a/internal/artifacts/testdata/mta/mta_no_paths.yaml
+++ b/internal/artifacts/testdata/mta/mta_no_paths.yaml
@@ -1,0 +1,11 @@
+ID: mta
+_schema-version: '2.1'
+version: 0.0.1
+
+modules:
+ - name: test_node-js
+   type: nodejs
+   provides:
+    - name: node-js_api
+      properties:
+         url: ${default-url}


### PR DESCRIPTION
Manifest fix. Skip module entry in manifest with no path attribute in module definition

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
