### PR TITLE
 gen mtad fixed to generate mtad.yaml in the source or target (if provided) 

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,7 +48,7 @@ func init() {
 	validateCmd.Flags().StringVarP(&validateCmdDesc, "desc", "d", "",
 		"the MTA descriptor; supported values: dev (development descriptor, default value) and dep (deployment descriptor)")
 	validateCmd.Flags().StringVarP(&validateCmdStrict, "strict", "r", "",
-		"if set to true duplicated fields and fields not defined in the mta yaml schema will be reported as errors, otherwise as warnings")
+		`if set to true, duplicated fields and fields not defined in the "mta.yaml" schema are reported as errors; if set to false, they are reported as warnings`)
 }
 
 // generateCmd - Parent of all generation commands

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,7 +48,7 @@ func init() {
 	validateCmd.Flags().StringVarP(&validateCmdDesc, "desc", "d", "",
 		"the MTA descriptor; supported values: dev (development descriptor, default value) and dep (deployment descriptor)")
 	validateCmd.Flags().StringVarP(&validateCmdStrict, "strict", "r", "",
-		"the strictness indicator; supported values: true (strict, default value) and false (not strict)")
+		"if set to true duplicated fields and fields not defined in the mta yaml schema will be reported as errors, otherwise as warnings")
 }
 
 // generateCmd - Parent of all generation commands

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -11,7 +11,6 @@ import (
 // mtad command flags
 var mtadCmdSrc string
 var mtadCmdTrg string
-var mtadCmdDesc string
 var mtadCmdPlatform string
 
 // meta command flags
@@ -33,8 +32,6 @@ func init() {
 		"the path to the MTA project; the current path is default")
 	mtadCmd.Flags().StringVarP(&mtadCmdTrg, "target", "t",
 		"", "the path to the MBT results folder; the current path is default")
-	mtadCmd.Flags().StringVarP(&mtadCmdDesc, "desc", "d", "",
-		"the MTA descriptor; supported values: dev (development descriptor, default value) and dep (deployment descriptor)")
 	mtadCmd.Flags().StringVarP(&mtadCmdPlatform, "platform", "p", "", "Provide MTA platform ")
 
 	// set flags of meta command
@@ -63,7 +60,7 @@ var mtadCmd = &cobra.Command{
 	Long:  "generates deployment descriptor (mtad.yaml) from development descriptor (mta.yaml)",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := artifacts.ExecuteGenMtad(mtadCmdSrc, mtadCmdTrg, mtadCmdDesc, mtadCmdPlatform, os.Getwd)
+		err := artifacts.ExecuteGenMtad(mtadCmdSrc, mtadCmdTrg, mtadCmdPlatform, os.Getwd)
 		logError(err)
 		return err
 	},

--- a/cmd/gen_test.go
+++ b/cmd/gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SAP/cloud-mta-build-tool/internal/fs"
 	"github.com/SAP/cloud-mta-build-tool/internal/platform"
+	"path/filepath"
 )
 
 var _ = Describe("Commands", func() {
@@ -32,7 +33,6 @@ var _ = Describe("Commands", func() {
 		var ep dir.Loc
 
 		AfterEach(func() {
-			mtadCmdDesc = ""
 			os.RemoveAll(getTestPath("result"))
 		})
 
@@ -48,12 +48,7 @@ var _ = Describe("Commands", func() {
 			mtadCmdSrc = getTestPath("mtahtml5")
 			mtadCmdPlatform = "cf"
 			Ω(mtadCmd.RunE(nil, []string{})).Should(Succeed())
-			Ω(ep.GetMtadPath()).Should(BeAnExistingFile())
-		})
-		It("Generate Mtad - Invalid deployment descriptor", func() {
-			mtadCmdSrc = getTestPath("mtahtml5")
-			mtadCmdDesc = "xx"
-			Ω(mtadCmd.RunE(nil, []string{})).Should(HaveOccurred())
+			Ω(filepath.Join(getTestPath("result"), "mtad.yaml")).Should(BeAnExistingFile())
 		})
 		It("Generate Mtad - Invalid source", func() {
 			mtadCmdSrc = getTestPath("mtahtml6")

--- a/integration/cloud_mta_build_tool_test.go
+++ b/integration/cloud_mta_build_tool_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Integration - CloudMtaBuildTool", func() {
 	AfterSuite(func() {
 		os.Remove("./testdata/mta_demo/" + mbtName)
 		os.Remove("./testdata/mta_demo/Makefile.mta")
+		os.Remove("./testdata/mta_demo/mtad.yaml")
 		os.Remove("./testdata/mta_demo/" + archiveName)
 		resourceCleanup("node")
 	})
@@ -94,7 +95,8 @@ var _ = Describe("Integration - CloudMtaBuildTool", func() {
 			path := dir + filepath.FromSlash("/testdata/mta_demo")
 			bin := filepath.FromSlash(binPath)
 			_, err, _ := execute(bin, "init 2", path)
-			Ω(err).ShouldNot(BeNil())
+			Ω(err).Should(Equal(""))
+
 		})
 	})
 
@@ -114,6 +116,17 @@ var _ = Describe("Integration - CloudMtaBuildTool", func() {
 			out, error := ioutil.ReadFile(filepath.Join(dir, "testdata", "mta_demo", "mta_archives", archiveName))
 			Ω(error).Should(BeNil())
 			Ω(out).ShouldNot(BeNil())
+		})
+	})
+
+	var _ = Describe("MBT gen commands", func() {
+		It("Generate mtad", func() {
+			dir, _ := os.Getwd()
+			path := filepath.Join(dir, "testdata", "mta_demo")
+			bin := filepath.FromSlash(binPath)
+			_, err, _ := execute(bin, "gen mtad", path)
+			Ω(err).Should(BeNil())
+			Ω(filepath.Join(path, "mtad.yaml")).Should(BeAnExistingFile())
 		})
 	})
 

--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -15,8 +15,7 @@ import (
 	"path/filepath"
 )
 
-
-type mtadLoc struct{
+type mtadLoc struct {
 	path string
 }
 

--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -12,12 +12,30 @@ import (
 	"github.com/SAP/cloud-mta-build-tool/internal/logs"
 
 	"github.com/SAP/cloud-mta/mta"
+	"path/filepath"
 )
 
+
+type mtadLoc struct{
+	path string
+}
+
+func (loc *mtadLoc) GetMtadPath() string {
+	return filepath.Join(loc.path, dir.Mtad)
+}
+
+func (loc *mtadLoc) GetMetaPath() string {
+	return loc.path
+}
+
+func (loc *mtadLoc) GetManifestPath() string {
+	return ""
+}
+
 // ExecuteGenMtad - generates MTAD from MTA
-func ExecuteGenMtad(source, target, desc, platform string, wdGetter func() (string, error)) error {
+func ExecuteGenMtad(source, target, platform string, wdGetter func() (string, error)) error {
 	logs.Logger.Info("generating the MTAD file...")
-	loc, err := dir.Location(source, target, desc, wdGetter)
+	loc, err := dir.Location(source, target, dir.Dev, wdGetter)
 	if err != nil {
 		return errors.Wrap(err, "generation of the MTAD file failed when initializing the location")
 	}
@@ -35,11 +53,7 @@ func ExecuteGenMtad(source, target, desc, platform string, wdGetter func() (stri
 	mta.Merge(mtaStr, mtaExt)
 	adaptMtadForDeployment(mtaStr, platform)
 
-	err = genMtad(mtaStr, loc, loc.IsDeploymentDescriptor(), platform, yaml.Marshal)
-	if err != nil {
-		return err
-	}
-	return nil
+	return genMtad(mtaStr, &mtadLoc{target}, false, platform, yaml.Marshal)
 }
 
 // genMtad generates an mtad.yaml file from a mta.yaml file and a platform configuration file.

--- a/internal/artifacts/mtad_test.go
+++ b/internal/artifacts/mtad_test.go
@@ -26,24 +26,24 @@ var _ = Describe("Mtad", func() {
 
 	var _ = Describe("ExecuteGenMtad", func() {
 		It("Sanity", func() {
-			Ω(ExecuteGenMtad(getTestPath("mta"), getTestPath("resultMtad"), "dev", "cf", os.Getwd)).Should(Succeed())
-			Ω(getTestPath("resultMtad", "mta_mta_build_tmp", "META-INF", "mtad.yaml")).Should(BeAnExistingFile())
+			Ω(ExecuteGenMtad(getTestPath("mta"), getTestPath("resultMtad"), "cf", os.Getwd)).Should(Succeed())
+			Ω(getTestPath("resultMtad", "mtad.yaml")).Should(BeAnExistingFile())
 		})
 		It("Fails on location initialization", func() {
-			Ω(ExecuteGenMtad("", getTestPath("resultMtad"), "dev", "cf", func() (string, error) {
+			Ω(ExecuteGenMtad("", getTestPath("resultMtad"), "cf", func() (string, error) {
 				return "", errors.New("err")
 			})).Should(HaveOccurred())
 		})
 		It("Fails on wrong source path - parse fails", func() {
-			Ω(ExecuteGenMtad(getTestPath("mtax"), getTestPath("resultMtad"), "dev", "cf", os.Getwd)).Should(HaveOccurred())
+			Ω(ExecuteGenMtad(getTestPath("mtax"), getTestPath("resultMtad"), "cf", os.Getwd)).Should(HaveOccurred())
 		})
 		It("Fails on broken extension file - parse ext fails", func() {
-			Ω(ExecuteGenMtad(getTestPath("mtaWithBrokenExt"), getTestPath("resultMtad"), "dev", "cf", os.Getwd)).Should(HaveOccurred())
+			Ω(ExecuteGenMtad(getTestPath("mtaWithBrokenExt"), getTestPath("resultMtad"), "cf", os.Getwd)).Should(HaveOccurred())
 		})
 		It("Fails on broken platforms configuration", func() {
 			cfg := platform.PlatformConfig
 			platform.PlatformConfig = []byte("abc abc")
-			Ω(ExecuteGenMtad(getTestPath("mta"), getTestPath("resultMtad"), "dev", "cf", os.Getwd)).Should(HaveOccurred())
+			Ω(ExecuteGenMtad(getTestPath("mta"), getTestPath("resultMtad"), "cf", os.Getwd)).Should(HaveOccurred())
 			platform.PlatformConfig = cfg
 		})
 	})

--- a/internal/fs/mta_location.go
+++ b/internal/fs/mta_location.go
@@ -16,7 +16,8 @@ const (
 	Dev = "dev"
 	// TempFolderSuffix - temporary folder suffix
 	TempFolderSuffix = "_mta_build_tmp"
-	mtad             = "mtad.yaml"
+	// Mtad - deployment descriptor file name
+	Mtad             = "mtad.yaml"
 )
 
 // IMtaParser - MTA Parser interface
@@ -140,7 +141,7 @@ func (ep *Loc) GetSourceModuleDir(modulePath string) string {
 func (ep *Loc) GetMtaYamlFilename() string {
 	if ep.MtaFilename == "" {
 		if ep.Descriptor == Dep {
-			return mtad
+			return Mtad
 		}
 		return "mta.yaml"
 	}
@@ -164,7 +165,7 @@ func (ep *Loc) GetMetaPath() string {
 
 // GetMtadPath gets the path to the generated MTAD file.
 func (ep *Loc) GetMtadPath() string {
-	return filepath.Join(ep.GetMetaPath(), mtad)
+	return filepath.Join(ep.GetMetaPath(), Mtad)
 }
 
 // GetManifestPath gets the path to the generated manifest file.

--- a/internal/fs/mta_location.go
+++ b/internal/fs/mta_location.go
@@ -17,7 +17,7 @@ const (
 	// TempFolderSuffix - temporary folder suffix
 	TempFolderSuffix = "_mta_build_tmp"
 	// Mtad - deployment descriptor file name
-	Mtad             = "mtad.yaml"
+	Mtad = "mtad.yaml"
 )
 
 // IMtaParser - MTA Parser interface


### PR DESCRIPTION
 gen mtad fixed to generate mtad.yaml in the source or target (if provided) 

- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
