### PR TITLE
 limit number of open files when copying entries in parallel

### DIFF
--- a/internal/archive/fsops.go
+++ b/internal/archive/fsops.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
 	"github.com/pkg/errors"
 
 	"github.com/SAP/cloud-mta-build-tool/internal/logs"


### PR DESCRIPTION
limit number of open files when copying entries in parallel

### Checklist
- [x] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
