### PR TITLE
fix assembly custom mtar name functionality

### DIFF
--- a/cmd/assembly.go
+++ b/cmd/assembly.go
@@ -25,7 +25,7 @@ var assemblyCommand = &cobra.Command{
 	ValidArgs: []string{"Deployment descriptor location"},
 	Args:      cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := artifacts.Assembly(assembleCmdSrc, assembleCmdTrg, defaultPlatform, mtarCmdMtarName, assembleCmdParallel, os.Getwd)
+		err := artifacts.Assembly(assembleCmdSrc, assembleCmdTrg, defaultPlatform, assembleCmdMtarName, assembleCmdParallel, os.Getwd)
 		logError(err)
 		return err
 	},


### PR DESCRIPTION
fix assembly custom mtar name functionality

### Checklist
- [x] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
