### PR TITLE
Fix error - when MTA build fails, the tools print ‘mbt build’ usage help

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -68,4 +68,6 @@ var buildCmd = &cobra.Command{
 		logError(err)
 		return err
 	},
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }


### PR DESCRIPTION
## Description

Fix error - when MTA build fails, the tools print ‘mbt build’ usage help

### Checklist
- [X] Code compiles correctly
- [X ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formating and linting run locally successfully
- [X ] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
