### PR TITLE
Change from go-npm to binwrap to allow local usage and avoid the glob…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ docker*
 .dockerignore
 .DS_Store
 dist
+node_modules
 
 cover.html
 cover.out

--- a/index.js
+++ b/index.js
@@ -1,0 +1,18 @@
+var binwrap = require('binwrap');
+var path = require('path');
+
+var packageInfo = require(path.join(__dirname, 'package.json'));
+var version = '0.2.7'; //packageInfo.version;
+var root = `https://github.com/SAP/cloud-mta-build-tool/releases/download/v${version}/cloud-mta-build-tool_${version}_`;
+
+module.exports = binwrap({
+  dirname: __dirname,
+  binaries: [
+    'mbt'
+  ],
+  urls: {
+    'darwin-x64': root + 'Darwin_amd64.tar.gz',
+    'linux-x64': root + 'Linux_amd64.tar.gz',
+    'win32-x64': root + 'Windows_amd64.tar.gz'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -3,15 +3,18 @@
   "version": "0.2.7",
   "description": "[![CircleCI](https://circleci.com/gh/SAP/cloud-mta-build-tool.svg?style=svg&circle-token=ecedd1dce3592adcd72ee4c61481972c32dcfad7)](https://circleci.com/gh/SAP/cloud-mta-build-tool) [![Go Report Card](https://goreportcard.com/badge/github.com/SAP/cloud-mta-build-tool)](https://goreportcard.com/report/github.com/SAP/cloud-mta-build-tool) [![Coverage Status](https://coveralls.io/repos/github/SAP/cloud-mta-build-tool/badge.svg?branch=cover)](https://coveralls.io/github/SAP/cloud-mta-build-tool?branch=cover) ![GitHub license](https://img.shields.io/badge/license-Apache_2.0-blue.svg) ![pre-alpha](https://img.shields.io/badge/Release-pre--alpha-orange.svg)",
   "main": "index.js",
-  "files": [],
-  "goBinary": {
-    "name": "mbt",
-    "path": "./bin",
-    "url": "https://github.com/SAP/cloud-mta-build-tool/releases/download/v{{version}}/cloud-mta-build-tool_{{version}}_{{platform}}_{{arch}}.tar.gz"
-  },
+  "files": [
+    "index.js",
+    "bin"
+  ],
   "scripts": {
-    "postinstall": "go-npm install",
-    "preuninstall": "go-npm uninstall"
+    "install": "binwrap-install",
+    "prepare": "binwrap-prepare",
+    "test": "binwrap-test",
+    "prepublish": "npm test"
+  },
+  "bin": {
+    "mbt": "bin/mbt"
   },
   "repository": {
     "type": "git",
@@ -24,6 +27,6 @@
   },
   "homepage": "https://github.com/SAP/cloud-mta-build-tool#readme",
   "dependencies": {
-    "go-npm": "^0.1.9"
+    "binwrap": "^0.2.1"
   }
 }


### PR DESCRIPTION
Before submitting a pull request, Please make sure the following:

## Description

Change the dependecy from go-npm to binwrap as this tool seems to be more popular (1700 weekly downloads vs 37500). Another biggest advantage of this implementation is that the mbt module can be installed locally now, i.e. a global installation is no longer required. This allows the usage of different mbt versions in different projects.

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added - NA
- [ ] Formating and linting run locally successfully
- [X] All tests passing
- [ ] UA review
- [ ] Design is documented - Not yet
- [ ] Extended the README / documentation, if necessary - Not yet
- [ ] Open source is approved - Not yet
