### PR TITLE
DEVXBUGS-4708 

### DIFF
--- a/internal/tpl/makefile.go
+++ b/internal/tpl/makefile.go
@@ -61,6 +61,11 @@ func makeFile(mtaParser dir.IMtaParser, loc dir.ITargetPath, makeFilename string
 		File mta.MTA
 	}
 
+	err := dir.CreateDirIfNotExist(loc.GetTarget())
+	if err != nil {
+		return err
+	}
+
 	// ParseFile file
 	m, err := mtaParser.ParseFile()
 	if err != nil {

--- a/internal/tpl/makefile_test.go
+++ b/internal/tpl/makefile_test.go
@@ -113,6 +113,10 @@ makefile_version: 0.0.0
 			ep := dir.Loc{SourcePath: filepath.Join(wd, "testdata"), TargetPath: filepath.Join(wd, "testdata"), MtaFilename: "xxx.yaml"}
 			Ω(genMakefile(&ep, &ep, &ep, makefile, "")).Should(HaveOccurred())
 		})
+		It("genMakefile testing with wrong target folder (file path)", func() {
+			ep := dir.Loc{SourcePath: filepath.Join(wd, "testdata"), TargetPath: filepath.Join(wd, "testdata", "mta.yaml"), MtaFilename: "xxx.yaml"}
+			Ω(genMakefile(&ep, &ep, &ep, makefile, "")).Should(HaveOccurred())
+		})
 		It("genMakefile testing with wrong mode", func() {
 			ep := dir.Loc{SourcePath: filepath.Join(wd, "testdata")}
 			Ω(genMakefile(&ep, &ep, &ep, makefile, "wrongMode")).Should(HaveOccurred())


### PR DESCRIPTION
mbt init -t=newFolder fails if "newFolder" does not exist

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
