### PR TITLE
fix manifest - handle build results as a folder

### DIFF
--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -195,7 +195,7 @@ func getModulePath(module *mta.Module, targetPathGetter dir.ITargetPath, default
 	loc := targetPathGetter.(*dir.Loc)
 
 	// get build results path - defined in build-params property or in
-	buildResultPath, buildResultDefined, err := buildops.GetBuildResultsPath(loc, module, defaultBuildResult)
+	buildResultPath, _, err := buildops.GetBuildResultsPath(loc, module, defaultBuildResult)
 	if err != nil {
 		return "", err
 	}
@@ -205,10 +205,7 @@ func getModulePath(module *mta.Module, targetPathGetter dir.ITargetPath, default
 		return module.Path, nil
 	}
 
-	definedArchive := false
-	if buildResultDefined {
-		definedArchive, _ = isArchive(buildResultPath)
-	}
+	definedArchive, _ := isArchive(buildResultPath)
 
 	if definedArchive {
 		return filepath.ToSlash(filepath.Join(module.Name, filepath.Base(buildResultPath))), nil

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -203,7 +203,14 @@ func getModulePath(module *mta.Module, targetPathGetter dir.ITargetPath, default
 	if buildResultPath == "" {
 		// module path not defined
 		return module.Path, nil
-	} else if buildResultDefined && isArchive(buildResultPath) {
+	}
+
+	definedArchive := false
+	if buildResultDefined {
+		definedArchive, _ = isArchive(buildResultPath)
+	}
+
+	if definedArchive {
 		return filepath.ToSlash(filepath.Join(module.Name, filepath.Base(buildResultPath))), nil
 	} else if existsModuleZipInDirectories(module, []string{loc.GetSource(), loc.GetTargetTmpDir()}) {
 		return filepath.ToSlash(module.Name + dataZip), nil

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -199,10 +199,11 @@ func getModulePath(module *mta.Module, targetPathGetter dir.ITargetPath, default
 	if err != nil {
 		return "", err
 	}
+
 	if buildResultPath == "" {
 		// module path not defined
 		return module.Path, nil
-	} else if buildResultDefined {
+	} else if buildResultDefined && isArchive(buildResultPath) {
 		return filepath.ToSlash(filepath.Join(module.Name, filepath.Base(buildResultPath))), nil
 	} else if existsModuleZipInDirectories(module, []string{loc.GetSource(), loc.GetTargetTmpDir()}) {
 		return filepath.ToSlash(module.Name + dataZip), nil

--- a/internal/artifacts/module_arch.go
+++ b/internal/artifacts/module_arch.go
@@ -187,6 +187,10 @@ func convert(data []interface{}) []string {
 }
 
 func isArchive(path string) bool {
+	entry, err := os.Stat(path)
+	if err != nil || entry.IsDir() {
+		return false
+	}
 	ext := filepath.Ext(path)
 	return ext == ".zip" || ext == ".jar" || ext == ".war"
 }

--- a/internal/artifacts/module_arch.go
+++ b/internal/artifacts/module_arch.go
@@ -146,7 +146,7 @@ func packModule(ep dir.IModule, deploymentDesc bool, module *mta.Module, moduleN
 	if buildResults != "" {
 		definedArchive, err = isArchive(buildResults)
 		if err != nil {
-			return errors.Wrapf(err, `packing of the "%v" module failed because could not find the "%s" build results`, moduleName, buildResults)
+			return errors.Wrapf(err, `packing of the "%v" module failed; could not find the "%s" build results`, moduleName, buildResults)
 		}
 	}
 

--- a/internal/artifacts/module_arch.go
+++ b/internal/artifacts/module_arch.go
@@ -146,7 +146,7 @@ func packModule(ep dir.IModule, deploymentDesc bool, module *mta.Module, moduleN
 	if buildResults != "" {
 		definedArchive, err = isArchive(buildResults)
 		if err != nil {
-			return errors.Wrapf(err, `could not find the "%s" build results`, buildResults)
+			return errors.Wrapf(err, `packing of the "%v" module failed because could not find the "%s" build results`, moduleName, buildResults)
 		}
 	}
 

--- a/internal/artifacts/module_arch.go
+++ b/internal/artifacts/module_arch.go
@@ -142,12 +142,7 @@ func packModule(ep dir.IModule, deploymentDesc bool, module *mta.Module, moduleN
 			moduleName)
 	}
 
-	entry, err := os.Stat(buildResults)
-	if err != nil {
-		return errors.Wrapf(err, `packing the "%v" module failed; the "%v" build results path does not exist`,
-			moduleName, buildResults)
-	}
-	if !entry.IsDir() && isArchive(buildResults) {
+	if isArchive(buildResults) {
 		err = dir.CopyFile(buildResults, filepath.Join(moduleZipPath, filepath.Base(buildResults)))
 		if err != nil {
 			return errors.Wrapf(err, `packing of the "%v" module failed when copying the "%s" path to the "%s" folder`,

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -484,6 +484,7 @@ module-types:
 		if expectedError {
 			Ω(err).Should(HaveOccurred())
 		} else {
+			Ω(err).Should(Succeed())
 			Ω(res).Should(Equal(expectedResult))
 		}
 	},

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -125,9 +125,9 @@ builders:
 			})
 			It("Build results - zip file not exists, fails", func() {
 				ep := dir.Loc{
-					SourcePath:  getTestPath("mta_with_zipped_module"),
-					TargetPath:  getResultPath(),
-					Descriptor:  "dev",
+					SourcePath: getTestPath("mta_with_zipped_module"),
+					TargetPath: getResultPath(),
+					Descriptor: "dev",
 				}
 				mod := mta.Module{
 					Name: "node-js",

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -471,6 +471,16 @@ module-types:
 		It("path not exists", func() {
 			Ω(isArchive(getTestPath("not_existing"))).Should(BeFalse())
 		})
+		It("path to archive", func() {
+			Ω(isArchive(getTestPath("mta_content_copy_test", "test.zip"))).Should(BeTrue())
+		})
+		It("path to folder", func() {
+			Ω(isArchive(getTestPath())).Should(BeFalse())
+		})
+		It("path to non archive file", func() {
+			Ω(isArchive(getTestPath("mta_content_copy_test", "test-content", "test"))).Should(BeFalse())
+		})
+
 	})
 })
 

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -123,6 +123,18 @@ builders:
 				Ω(packModule(&ep, false, &m, "node-js", "cf", "*.zip")).Should(Succeed())
 				Ω(getTestPath("result", ".mta_with_zipped_module_mta_build_tmp", "node-js", "abc.zip")).Should(BeAnExistingFile())
 			})
+			It("Build results - zip file not exists, fails", func() {
+				ep := dir.Loc{
+					SourcePath:  getTestPath("mta_with_zipped_module"),
+					TargetPath:  getResultPath(),
+					Descriptor:  "dev",
+				}
+				mod := mta.Module{
+					Name: "node-js",
+					Path: "notExists",
+				}
+				Ω(packModule(&ep, false, &mod, "node-js", "cf", "*.zip")).Should(HaveOccurred())
+			})
 
 			It("ignore case", func() {
 				m := mta.Module{
@@ -467,21 +479,18 @@ module-types:
 		})
 	})
 
-	var _ = Describe("isArchive", func() {
-		It("path not exists", func() {
-			Ω(isArchive(getTestPath("not_existing"))).Should(BeFalse())
-		})
-		It("path to archive", func() {
-			Ω(isArchive(getTestPath("mta_content_copy_test", "test.zip"))).Should(BeTrue())
-		})
-		It("path to folder", func() {
-			Ω(isArchive(getTestPath())).Should(BeFalse())
-		})
-		It("path to non archive file", func() {
-			Ω(isArchive(getTestPath("mta_content_copy_test", "test-content", "test"))).Should(BeFalse())
-		})
-
-	})
+	var _ = DescribeTable("isArchive", func(path string, expectedResult, expectedError bool) {
+		res, err := isArchive(path)
+		if expectedError {
+			Ω(err).Should(HaveOccurred())
+		} else {
+			Ω(res).Should(Equal(expectedResult))
+		}
+	},
+		Entry("path not exists", getTestPath("not_existing"), false, true),
+		Entry("path to archive", getTestPath("mta_content_copy_test", "test.zip"), true, false),
+		Entry("path to folder", getTestPath(), false, false),
+		Entry("path to non archive file", getTestPath("mta_content_copy_test", "test-content", "test"), false, false))
 })
 
 func dirContainsAllElements(source string, elements map[string]bool, validateEntitiesCount bool) bool {

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -466,6 +466,12 @@ module-types:
 			Ω(err).Should(Succeed())
 		})
 	})
+
+	var _ = Describe("isArchive", func() {
+		It("path not exists", func() {
+			Ω(isArchive(getTestPath("not_existing"))).Should(BeFalse())
+		})
+	})
 })
 
 func dirContainsAllElements(source string, elements map[string]bool, validateEntitiesCount bool) bool {

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -481,11 +481,11 @@ module-types:
 
 	var _ = DescribeTable("isArchive", func(path string, expectedResult, expectedError bool) {
 		res, err := isArchive(path)
+		Ω(res).Should(Equal(expectedResult))
 		if expectedError {
 			Ω(err).Should(HaveOccurred())
 		} else {
 			Ω(err).Should(Succeed())
-			Ω(res).Should(Equal(expectedResult))
 		}
 	},
 		Entry("path not exists", getTestPath("not_existing"), false, true),


### PR DESCRIPTION
fix manifest - handle build results as a folder

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
