### PR TITLE
Use cloud-mta-build-tool version from package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var binwrap = require('binwrap');
 var path = require('path');
 
 var packageInfo = require(path.join(__dirname, 'package.json'));
-var version = '0.2.7'; //packageInfo.version;
+var version = packageInfo.version;
 var root = `https://github.com/SAP/cloud-mta-build-tool/releases/download/v${version}/cloud-mta-build-tool_${version}_`;
 
 module.exports = binwrap({


### PR DESCRIPTION
## Description

Use cloud-mta-build-tool version from package.json, it is currently hard coded to 0.2.7

### Checklist
- [x] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [x] Formating and linting run locally successfully
- [x] All tests passing
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
