### PR TITLE
Only run 1 indicator in mbt build

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -17,7 +17,7 @@ var executeCommand = &cobra.Command{
 	Long:  "Execute commands in the current working directory with timeout",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := exec.ExecuteCommandsWithTimeout(executeCmdCommands, executeCmdTimeout)
+		err := exec.ExecuteCommandsWithTimeout(executeCmdCommands, executeCmdTimeout, true)
 		logError(err)
 		return err
 	},

--- a/internal/artifacts/module_arch.go
+++ b/internal/artifacts/module_arch.go
@@ -100,7 +100,7 @@ func buildModule(mtaParser dir.IMtaParser, moduleLoc dir.IModule, targetLoc dir.
 			return errors.Errorf(exec.ExecInvalidTimeoutMsg, fmt.Sprint(module.BuildParams["timeout"]))
 		}
 	}
-	e = exec.ExecuteWithTimeout(commandList, timeout)
+	e = exec.ExecuteWithTimeout(commandList, timeout, true)
 	if e != nil {
 		return errors.Wrapf(e, buildFailedMsg, moduleName)
 	}

--- a/internal/artifacts/project.go
+++ b/internal/artifacts/project.go
@@ -21,16 +21,16 @@ const (
 )
 
 // ExecBuild - Execute MTA project build
-func ExecBuild(makefileTmp, buildProjectCmdSrc, buildProjectCmdTrg, buildProjectCmdMode, buildProjectCmdMtar, buildProjectCmdPlatform string, buildProjectCmdStrict bool, wdGetter func() (string, error), wdExec func([][]string) error, useDefaultMbt bool) error {
+func ExecBuild(makefileTmp, buildProjectCmdSrc, buildProjectCmdTrg, buildProjectCmdMode, buildProjectCmdMtar, buildProjectCmdPlatform string, buildProjectCmdStrict bool, wdGetter func() (string, error), wdExec func([][]string, bool) error, useDefaultMbt bool) error {
 	// Generate build script
 	err := tpl.ExecuteMake(buildProjectCmdSrc, "", makefileTmp, buildProjectCmdMode, wdGetter, useDefaultMbt)
 	if err != nil {
 		return err
 	}
 	if buildProjectCmdTrg == "" {
-		err = wdExec([][]string{{buildProjectCmdSrc, "make", "-f", makefileTmp, "p=" + buildProjectCmdPlatform, "mtar=" + buildProjectCmdMtar, "strict=" + strconv.FormatBool(buildProjectCmdStrict), "mode=" + buildProjectCmdMode}})
+		err = wdExec([][]string{{buildProjectCmdSrc, "make", "-f", makefileTmp, "p=" + buildProjectCmdPlatform, "mtar=" + buildProjectCmdMtar, "strict=" + strconv.FormatBool(buildProjectCmdStrict), "mode=" + buildProjectCmdMode}}, false)
 	} else {
-		err = wdExec([][]string{{buildProjectCmdSrc, "make", "-f", makefileTmp, "p=" + buildProjectCmdPlatform, "mtar=" + buildProjectCmdMtar, `t="` + buildProjectCmdTrg + `"`, "strict=" + strconv.FormatBool(buildProjectCmdStrict), "mode=" + buildProjectCmdMode}})
+		err = wdExec([][]string{{buildProjectCmdSrc, "make", "-f", makefileTmp, "p=" + buildProjectCmdPlatform, "mtar=" + buildProjectCmdMtar, `t="` + buildProjectCmdTrg + `"`, "strict=" + strconv.FormatBool(buildProjectCmdStrict), "mode=" + buildProjectCmdMode}}, false)
 	}
 	// Remove temporary Makefile
 	removeError := os.Remove(filepath.Join(buildProjectCmdSrc, filepath.FromSlash(makefileTmp)))
@@ -96,7 +96,7 @@ func execProjectBuilder(builders []mta.ProjectBuilder, phase string) error {
 			return errors.Wrapf(err, errMessage, phase)
 		}
 		// Execute commands
-		err = exec.ExecuteWithTimeout(cmds, builder.Timeout)
+		err = exec.ExecuteWithTimeout(cmds, builder.Timeout, true)
 		if err != nil {
 			return errors.Wrapf(err, errMessage, phase)
 		}

--- a/internal/artifacts/project_test.go
+++ b/internal/artifacts/project_test.go
@@ -53,14 +53,14 @@ var _ = Describe("Project", func() {
 			Ω(os.RemoveAll(getTestPath("result"))).Should(Succeed())
 		})
 		It("Sanity", func() {
-			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), "", "", "cf", true, os.Getwd, func(strings [][]string) error {
+			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), "", "", "cf", true, os.Getwd, func(strings [][]string, b bool) error {
 				return nil
 			}, true)
 			Ω(err).Should(Succeed())
 			Ω(filepath.Join(getResultPath(), "Makefile_tmp.mta")).ShouldNot(BeAnExistingFile())
 		})
 		It("Wrong - no platform", func() {
-			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), "", "", "", true, os.Getwd, func(strings [][]string) error {
+			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), "", "", "", true, os.Getwd, func(strings [][]string, b bool) error {
 				return fmt.Errorf("failure")
 			}, true)
 			Ω(err).Should(HaveOccurred())

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -31,13 +31,13 @@ var _ = Describe("Execute", func() {
 	var _ = Describe("Execute call", func() {
 
 		var _ = DescribeTable("Valid input", func(args [][]string) {
-			Ω(Execute(args)).Should(Succeed())
+			Ω(Execute(args, false)).Should(Succeed())
 		},
 			Entry("EchoTesting", [][]string{{"", "bash", "-c", `echo -n {"Name": "Bob", "Age": 32}`}}),
 			Entry("Dummy Go Testing", [][]string{{"", "go", "test", "exec_dummy_test.go"}}))
 
 		var _ = DescribeTable("Invalid input", func(args [][]string) {
-			Ω(Execute(args)).Should(HaveOccurred())
+			Ω(Execute(args, false)).Should(HaveOccurred())
 		},
 			Entry("Valid command fails on input", [][]string{{"", "go", "test", "exec_unknown_test.go"}}),
 			Entry("Invalid command", [][]string{{"", "dateXXX"}}),
@@ -46,7 +46,7 @@ var _ = Describe("Execute", func() {
 
 	var _ = DescribeTable("executeCommand Failures",
 		func(cmd *exec.Cmd) {
-			Ω(executeCommand(cmd, make(chan struct{}))).Should(HaveOccurred())
+			Ω(executeCommand(cmd, make(chan struct{}), true)).Should(HaveOccurred())
 		},
 
 		Entry("fails on StdoutPipe", &exec.Cmd{Stdout: &testStr{}}),
@@ -117,7 +117,7 @@ var _ = Describe("Execute", func() {
 	DescribeTable("ExecuteWithTimeout",
 		func(args [][]string, timeout string, minSeconds, maxSeconds int, isError bool, expectedTimeout string) {
 			executeTester(func() error {
-				return ExecuteWithTimeout(args, timeout)
+				return ExecuteWithTimeout(args, timeout, true)
 			}, minSeconds, maxSeconds, isError, expectedTimeout)
 		},
 		Entry("succeeds when timeout wasn't reached", [][]string{{"", "bash", "-c", "sleep 2"}}, "10s", 2, 5, false, ""),
@@ -127,7 +127,7 @@ var _ = Describe("Execute", func() {
 	)
 
 	It("ExecuteWithTimeout fails when timeout value is invalid", func() {
-		err := ExecuteWithTimeout([][]string{{"bash", "-c", "sleep 1"}}, "1234")
+		err := ExecuteWithTimeout([][]string{{"bash", "-c", "sleep 1"}}, "1234", true)
 		Ω(err).Should(HaveOccurred())
 		Ω(err.Error()).Should(ContainSubstring(fmt.Sprintf(ExecInvalidTimeoutMsg, "1234")))
 	})
@@ -135,7 +135,7 @@ var _ = Describe("Execute", func() {
 	DescribeTable("ExecuteCommandsWithTimeout",
 		func(args []string, timeout string, minSeconds, maxSeconds int, isError bool, expectedTimeout string) {
 			executeTester(func() error {
-				return ExecuteCommandsWithTimeout(args, timeout)
+				return ExecuteCommandsWithTimeout(args, timeout, true)
 			}, minSeconds, maxSeconds, isError, expectedTimeout)
 		},
 		Entry("succeeds when timeout wasn't reached", []string{`bash -c "sleep 2"`}, "10s", 2, 5, false, ""),
@@ -145,7 +145,7 @@ var _ = Describe("Execute", func() {
 	)
 
 	It("ExecuteCommandsWithTimeout fails when timeout value is invalid", func() {
-		err := ExecuteCommandsWithTimeout([]string{`bash -c "sleep 1"`}, "1234")
+		err := ExecuteCommandsWithTimeout([]string{`bash -c "sleep 1"`}, "1234", true)
 		Ω(err).Should(HaveOccurred())
 		Ω(err.Error()).Should(ContainSubstring(fmt.Sprintf(ExecInvalidTimeoutMsg, "1234")))
 	})


### PR DESCRIPTION
## Description

The indicator will run for the module builds and not for the make command
(same as when running form mbt init && make).

### Checklist
- [X] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
