### PR TITLE
[Fix] Unnecessary folder is packaged in mtar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - test:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: master
 
   on_merge_build_test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,12 @@ workflows:
           filters:
             branches:
               ignore: master
+      - test:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
 
   on_merge_build_test:
     jobs:

--- a/integration/cloud_mta_build_tool_test.go
+++ b/integration/cloud_mta_build_tool_test.go
@@ -367,12 +367,12 @@ modules:
 		var mtaAssemblePath string
 
 		BeforeEach(func() {
-			mtaAssemblePath = currentWorkingDirectory + filepath.FromSlash("/testdata/mta_assemble")
 			currentWorkingDirectory, _ = os.Getwd()
+			mtaAssemblePath = currentWorkingDirectory + filepath.FromSlash("/testdata/mta_assemble")
 		})
 
 		AfterEach(func() {
-			os.RemoveAll(filepath.Join(mtaAssemblePath, "mta.assembly.example.mtar"))
+			Ω(os.RemoveAll(filepath.Join(mtaAssemblePath, "mta.assembly.example.mtar"))).Should(Succeed())
 			os.Chdir(currentWorkingDirectory)
 		})
 

--- a/integration/cloud_mta_build_tool_test.go
+++ b/integration/cloud_mta_build_tool_test.go
@@ -163,8 +163,8 @@ var _ = Describe("Integration - CloudMtaBuildTool", func() {
 				}
 				Ω(err).Should(Equal(""))
 
-				// Check the MTAR was generates
-				validateMtaArchiveContents([]string{"node-js/data.zip"}, filepath.Join(path, "mta_archives", "mta_demo_0.0.1.mtar"))
+				// Check the MTAR was generated
+				validateMtaArchiveContents([]string{"node/", "node/data.zip", "node-js/", "node-js/data.zip"}, filepath.Join(path, "mta_archives", "mta_demo_0.0.1.mtar"))
 			})
 
 			It("MBT build - wrong platform", func() {
@@ -250,7 +250,7 @@ modules:
 `))
 			Ω(e).Should(Succeed())
 			Ω(actual).Should(Equal(expected))
-			validateMtaArchiveContents([]string{"node-js/data.zip"}, filepath.Join(path, "mta_archives", "mta_demo_0.0.1.mtar"))
+			validateMtaArchiveContents([]string{"node/", "node/data.zip", "node-js/", "node-js/data.zip"}, filepath.Join(path, "mta_archives", "mta_demo_0.0.1.mtar"))
 		})
 		It("Generate MTAR for mta_java", func() {
 
@@ -295,7 +295,7 @@ modules:
 			//`))
 			//			Ω(e).Should(Succeed())
 			//			Ω(actual).Should(Equal(expected))
-			//			validateMtaArchiveContents([]string{"META-INF/MANIFEST.MF", "META-INF/mtad.yaml", "myModule/java-xsahaa-1.1.2.war"}, filepath.Join(path, "mta_archives", "com.fetcher.project_0.0.1.mtar"))
+			//			validateMtaArchiveContents([]string{"myModule/", "myModule/java-xsahaa-1.1.2.war"}, filepath.Join(path, "mta_archives", "com.fetcher.project_0.0.1.mtar"))
 		})
 	})
 
@@ -365,10 +365,18 @@ modules:
 	var _ = Describe("Assemble MTAR", func() {
 		var currentWorkingDirectory string
 		var mtaAssemblePath string
-		It("Assemble MTAR", func() {
-			currentWorkingDirectory, _ = os.Getwd()
-			mtaAssemblePath = currentWorkingDirectory + filepath.FromSlash("/testdata/mta_assemble")
 
+		BeforeEach(func() {
+			mtaAssemblePath = currentWorkingDirectory + filepath.FromSlash("/testdata/mta_assemble")
+			currentWorkingDirectory, _ = os.Getwd()
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(filepath.Join(mtaAssemblePath, "mta.assembly.example.mtar"))
+			os.Chdir(currentWorkingDirectory)
+		})
+
+		It("Assemble MTAR", func() {
 			bin := filepath.FromSlash(binPath)
 			cmdOut, err, _ := execute(bin, "assemble", mtaAssemblePath)
 			Ω(err).Should(Equal(""))
@@ -380,9 +388,12 @@ modules:
 			Ω(cmdOut).Should(ContainSubstring("the MTA archive generated at: " + filepath.Join(mtaAssemblePath, "mta_archives", "mta.assembly.example_1.3.3.mtar") + "\n"))
 			Ω(cmdOut).Should(ContainSubstring("cleaning temporary files..." + "\n"))
 			Ω(filepath.Join(mtaAssemblePath, "mta_archives", "mta.assembly.example_1.3.3.mtar")).Should(BeAnExistingFile())
-			validateMtaArchiveContents([]string{"META-INF/mtad.yaml", "META-INF/MANIFEST.MF", "node.zip", "xs-security.json"}, filepath.Join(mtaAssemblePath, "mta_archives", "mta.assembly.example_1.3.3.mtar"))
-			os.Remove(filepath.Join(mtaAssemblePath, "mta.assembly.example.mtar"))
-			os.Chdir(currentWorkingDirectory)
+			validateMtaArchiveContents([]string{
+				"node.zip", "xs-security.json",
+				"node/", "node/.eslintrc", "node/.eslintrc.ext", "node/.gitignore", "node/.npmrc", "node/jest.json", "node/package.json", "node/runTest.js", "node/server.js",
+				"node/.che/", "node/.che/project.json",
+				"node/tests/", "node/tests/sample-spec.js",
+			}, filepath.Join(mtaAssemblePath, "mta_archives", "mta.assembly.example_1.3.3.mtar"))
 		})
 	})
 })
@@ -409,18 +420,21 @@ func getFileContentFromZip(path string, filename string) ([]byte, error) {
 	return nil, fmt.Errorf(`file "%s" not found`, filename)
 }
 
-func validateMtaArchiveContents(expectedFilesInArchive []string, archiveLocation string) {
+func validateMtaArchiveContents(expectedAdditionalFilesInArchive []string, archiveLocation string) {
+	expectedFilesInArchive := append(expectedAdditionalFilesInArchive, "META-INF/", "META-INF/MANIFEST.MF", "META-INF/mtad.yaml")
 	archiveReader, err := zip.OpenReader(archiveLocation)
-	Ω(err).Should(BeNil())
+	Ω(err).Should(Succeed())
 	defer archiveReader.Close()
 	var filesInArchive []string
 	for _, file := range archiveReader.File {
 		filesInArchive = append(filesInArchive, file.Name)
 	}
 	for _, expectedFile := range expectedFilesInArchive {
-		Ω(contains(expectedFile, filesInArchive)).Should(BeTrue())
+		Ω(contains(expectedFile, filesInArchive)).Should(BeTrue(), fmt.Sprintf("expected %s to be in the archive; archive contains %v", expectedFile, filesInArchive))
 	}
-
+	for _, existingFile := range filesInArchive {
+		Ω(contains(existingFile, expectedFilesInArchive)).Should(BeTrue(), fmt.Sprintf("did not expect %s to be in the archive; archive contains %v", existingFile, filesInArchive))
+	}
 }
 
 func contains(element string, elements []string) bool {

--- a/internal/archive/fsops.go
+++ b/internal/archive/fsops.go
@@ -122,14 +122,8 @@ func walk(sourcePath string, baseDir string, archive *zip.Writer, ignore map[str
 		}
 
 		// Don't add the base folder to the zip
-		if info.IsDir() {
-			pathWithSlash := path
-			if !strings.HasSuffix(pathWithSlash, string(os.PathSeparator)) {
-				pathWithSlash += string(os.PathSeparator)
-			}
-			if pathWithSlash == baseDir {
-				return nil
-			}
+		if info.IsDir() && filepath.Clean(path) == filepath.Clean(baseDir) {
+			return nil
 		}
 
 		// Path in zip should be with slashes (in all operating systems)


### PR DESCRIPTION
## Description

When building an mtar, the temporary folder of the mta build was packaged
in the mtar without any files in it, under the full path of the folder in
the file system.

Added a check in the tests that exactly the files and folders we expect are
archived.

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
