### PR TITLE
[Fix] Different inner map type sometimes returned when reading fetcher-opts

### DIFF
--- a/internal/artifacts/meta_test.go
+++ b/internal/artifacts/meta_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 
 	"github.com/SAP/cloud-mta-build-tool/internal/archive"
 	"github.com/SAP/cloud-mta-build-tool/internal/platform"
@@ -70,32 +69,32 @@ modules:
 `)
 
 		It("Sanity", func() {
-			m := mta.MTA{}
-			Ω(yaml.Unmarshal(mtaSingleModule, &m)).Should(Succeed())
+			m, err := mta.Unmarshal(mtaSingleModule)
+			Ω(err).Should(Succeed())
 			createDirInTmpFolder("testproject", "htmlapp")
 			createFileInTmpFolder("testproject", "htmlapp", "data.zip")
 			createDirInTmpFolder("testproject", "META-INF")
-			Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", &m, true)).Should(Succeed())
+			Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", m, true)).Should(Succeed())
 			Ω(ep.GetManifestPath()).Should(BeAnExistingFile())
 			Ω(ep.GetMtadPath()).Should(BeAnExistingFile())
 		})
 
 		It("Meta creation fails - fails on conversion by platform", func() {
-			m := mta.MTA{}
-			Ω(yaml.Unmarshal(mtaSingleModule, &m)).Should(Succeed())
+			m, err := mta.Unmarshal(mtaSingleModule)
+			Ω(err).Should(Succeed())
 			createDirInTmpFolder("testproject", "app")
 			createDirInTmpFolder("testproject", "META-INF")
 			cfg := platform.PlatformConfig
 			platform.PlatformConfig = []byte(`very bad config`)
-			Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", &m, true)).Should(HaveOccurred())
+			Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", m, true)).Should(HaveOccurred())
 			platform.PlatformConfig = cfg
 		})
 
 		It("Fails on create file for manifest path", func() {
 			loc := testLoc{ep}
-			m := mta.MTA{}
-			Ω(yaml.Unmarshal(mtaSingleModule, &m)).Should(Succeed())
-			Ω(genMetaInfo(&loc, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", &m, true)).Should(HaveOccurred())
+			m, err := mta.Unmarshal(mtaSingleModule)
+			Ω(err).Should(Succeed())
+			Ω(genMetaInfo(&loc, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", m, true)).Should(HaveOccurred())
 		})
 
 		var _ = Describe("Fails on setManifestDesc", func() {
@@ -117,9 +116,9 @@ cli_version:["x"]
 			})
 
 			It("Fails on get version", func() {
-				m := mta.MTA{}
-				Ω(yaml.Unmarshal(mtaSingleModule, &m)).Should(Succeed())
-				Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", &m, true)).Should(HaveOccurred())
+				m, err := mta.Unmarshal(mtaSingleModule)
+				Ω(err).Should(Succeed())
+				Ω(genMetaInfo(&ep, &ep, &ep, ep.IsDeploymentDescriptor(), "cf", m, true)).Should(HaveOccurred())
 			})
 		})
 	})

--- a/internal/artifacts/project_test.go
+++ b/internal/artifacts/project_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 
 	"github.com/SAP/cloud-mta-build-tool/internal/archive"
 	"github.com/SAP/cloud-mta-build-tool/internal/commands"
@@ -208,19 +207,11 @@ builders:
 			commands.BuilderTypeConfig = buildersCfg
 		})
 		Context("pre & post builder commands", func() {
-			oMta := &mta.MTA{}
-			BeforeEach(func() {
+			It("parses pre and post commands", func() {
 				mtaFile, _ := ioutil.ReadFile("./testdata/mta/mta.yaml")
-				Ω(yaml.Unmarshal(mtaFile, oMta)).Should(Succeed())
-			})
-		})
-		Context("pre & post builder commands - no builders defined", func() {
-			oMta := &mta.MTA{}
-			BeforeEach(func() {
-				mtaFile, _ := ioutil.ReadFile("./testdata/mta/mta.yaml")
-				Ω(yaml.Unmarshal(mtaFile, oMta)).Should(Succeed())
-				oMta.BuildParams.BeforeAll = nil
-				oMta.BuildParams.AfterAll = nil
+				var err error
+				_, err = mta.Unmarshal(mtaFile)
+				Ω(err).Should(Succeed())
 			})
 		})
 	})

--- a/internal/buildops/build_params.go
+++ b/internal/buildops/build_params.go
@@ -48,7 +48,7 @@ func getBuildRequires(module *mta.Module) []BuildRequires {
 			// cast requirement to generic map
 			reqMap, ok := reqI.(map[string]interface{})
 			if !ok {
-				reqMap = convert(reqI.(map[interface{}]interface{}))
+				reqMap = commands.ConvertMap(reqI.(map[interface{}]interface{}))
 			}
 			// init resulting typed requirement
 			reqStr := BuildRequires{
@@ -71,17 +71,6 @@ func getBuildRequires(module *mta.Module) []BuildRequires {
 		return buildRequires
 	}
 	return nil
-}
-
-// Convert type map[interface{}]interface{} to map[string]interface{}
-func convert(m map[interface{}]interface{}) map[string]interface{} {
-	res := make(map[string]interface{})
-	for key, value := range m {
-		strKey := key.(string)
-		res[strKey] = value
-	}
-
-	return res
 }
 
 // getStrParam - get string parameter from the map

--- a/internal/buildops/build_params_test.go
+++ b/internal/buildops/build_params_test.go
@@ -2,11 +2,8 @@ package buildops
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -371,7 +368,7 @@ var _ = Describe("GetBuilder", func() {
 			Type: "node-js",
 			BuildParams: map[string]interface{}{
 				builderParam: "npm",
-				"npm-opts": map[interface{}]interface{}{
+				"npm-opts": map[string]interface{}{
 					"no-optional": nil,
 				},
 			},
@@ -419,13 +416,14 @@ var _ = Describe("GetBuilder", func() {
 		Ω(err).Should(Succeed())
 	})
 	It("fetcher builder defined by build params from mta.yaml", func() {
-		dir, _ := os.Getwd()
-		path := filepath.Join(dir, "testdata", "mtaWithFetcher.yaml")
-		// Read MTA file
-		yamlFile, err := ioutil.ReadFile(path)
+		currDir, err := os.Getwd()
 		Ω(err).Should(Succeed())
-		m := mta.MTA{}
-		yaml.Unmarshal(yamlFile, &m)
+		loc, err := dir.Location(filepath.Join(currDir, "testdata"), "", "dev", os.Getwd)
+		Ω(err).Should(Succeed())
+		loc.MtaFilename = "mtaWithFetcher.yaml"
+		m, err := loc.ParseFile()
+		Ω(err).Should(Succeed())
+
 		builder, custom, options, cmds, err := commands.GetBuilder(m.Modules[0])
 		Ω(options).Should(Equal(map[string]string{
 			"repo-type":        "maven",

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -72,22 +72,36 @@ func getOpts(module *mta.Module, optsParamName string) map[string]string {
 	options := module.BuildParams[optsParamName]
 	optionsMap := make(map[string]string)
 	if options != nil {
-		optionsMap = convert(options.(map[interface{}]interface{}))
+		optionsMapS, ok := options.(map[string]interface{})
+		if !ok {
+			optionsMapS = ConvertMap(options.(map[interface{}]interface{}))
+		}
+		optionsMap = convert(optionsMapS)
 	}
 
 	return optionsMap
 }
 
-// Convert type map[interface{}]interface{} to map[string]string
-func convert(m map[interface{}]interface{}) map[string]string {
+// Convert type map[string]interface{} to map[string]string
+func convert(m map[string]interface{}) map[string]string {
 	res := make(map[string]string)
-	for key, value := range m {
-		strKey := key.(string)
+	for strKey, value := range m {
 		strValue := ""
 		if value != nil {
 			strValue = value.(string)
 		}
 		res[strKey] = strValue
+	}
+
+	return res
+}
+
+// ConvertMap converts type map[interface{}]interface{} to map[string]interface{}
+func ConvertMap(m map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for key, value := range m {
+		strKey := key.(string)
+		res[strKey] = value
 	}
 
 	return res

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -262,10 +262,10 @@ modules:
     path: app
 `)
 
-			m := mta.MTA{}
+			m, err := mta.Unmarshal(mtaCF)
 			// parse mta yaml
-			Ω(yaml.Unmarshal(mtaCF, &m)).Should(Succeed())
-			module, commands, _, err := moduleCmd(&m, "htmlapp")
+			Ω(err).Should(Succeed())
+			module, commands, _, err := moduleCmd(m, "htmlapp")
 			Ω(err).Should(Succeed())
 			Ω(module.Path).Should(Equal("app"))
 			Ω(commands).Should(Equal([]string{"npm install --production"}))
@@ -285,10 +285,10 @@ modules:
       builder: npm
 `)
 
-			m := mta.MTA{}
+			m, err := mta.Unmarshal(mtaCF)
 			// parse mta yaml
-			Ω(yaml.Unmarshal(mtaCF, &m)).Should(Succeed())
-			module, commands, _, err := moduleCmd(&m, "htmlapp")
+			Ω(err).Should(Succeed())
+			module, commands, _, err := moduleCmd(m, "htmlapp")
 			Ω(err).Should(BeNil())
 			Ω(module.Path).Should(Equal("app"))
 			Ω(commands).Should(Equal([]string{"npm install --production"}))
@@ -311,10 +311,10 @@ modules:
          repo-coordinates: com.sap.xs.java:xs-audit-log-api:1.2.3
 
 `)
-			m := mta.MTA{}
+			m, err := mta.Unmarshal(mtaCF)
 			// parse mta yaml
-			Ω(yaml.Unmarshal(mtaCF, &m)).Should(Succeed())
-			module, commands, _, err := moduleCmd(&m, "htmlapp")
+			Ω(err).Should(Succeed())
+			module, commands, _, err := moduleCmd(m, "htmlapp")
 			Ω(err).Should(BeNil())
 			Ω(module.Path).Should(Equal("app"))
 			Ω(commands).Should(Equal([]string{"mvn -B dependency:copy -Dartifact=com.sap.xs.java:xs-audit-log-api:1.2.3 -DoutputDirectory=./target"}))


### PR DESCRIPTION
## Description

Support both cases (map[string]interface{} and map[interface{}]interface{})
Change all tests to use mta.Unmarshal instead of yaml.Unmarshal when
parsing mta

Before submitting a pull request, please ensure the following:

### Checklist
- [X] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
