### PR TITLE
Revert "Update Gopkg.toml"

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
 
 
 [[constraint]]
+  branch = "master"
   name = "github.com/SAP/cloud-mta"
-  branch = "0.0.5"
 
 [[constraint]]
   name = "github.com/deckarep/golang-set"
@@ -68,6 +68,3 @@
 [prune]
   go-tests = true
   unused-packages = true
-  
-  
-  


### PR DESCRIPTION
This reverts commit 7c006b50df6efa62c6e20a9dac344bcb600dbd96.

This change caused build failures:

Solving failure: No versions of github.com/SAP/cloud-mta met constraints:
	master: Could not introduce github.com/SAP/cloud-mta@master, as it is not allowed by constraint 0.0.5 from project github.com/SAP/cloud-mta-build-tool.
	v0.0.5: Could not introduce github.com/SAP/cloud-mta@v0.0.5, as it is not allowed by constraint 0.0.5 from project github.com/SAP/cloud-mta-build-tool.
	v0.0.4: Could not introduce github.com/SAP/cloud-mta@v0.0.4, as it is not allowed by constraint 0.0.5 from project github.com/SAP/cloud-mta-build-tool.
etc

### Checklist
- [X] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
