### PR TITLE
Support copying a file for build dependencies

### DIFF
--- a/internal/archive/fsops.go
+++ b/internal/archive/fsops.go
@@ -413,8 +413,18 @@ func CopyByPatterns(source, target string, patterns []string) error {
 func copyByPattern(source, target, pattern string) error {
 	logs.Logger.Infof(`copying the "%s" pattern from the "%s" folder to the "%s" folder`,
 		pattern, source, target)
-	// build full pattern concatenating source path and pattern
-	fullPattern := filepath.Join(source, strings.Replace(pattern, "./", "", -1))
+	// Check if the source is a file or a folder. If it's a file, the pattern "*" should copy the file itself.
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	var fullPattern string
+	if !info.IsDir() && pattern == "*" {
+		fullPattern = source
+	} else {
+		// build full pattern concatenating source path and pattern
+		fullPattern = filepath.Join(source, strings.Replace(pattern, "./", "", -1))
+	}
 	// get all entries matching the pattern
 	sourceEntries, err := filepath.Glob(fullPattern)
 	if err != nil {


### PR DESCRIPTION
## Description
This is done by specifying `*` as the pattern, when the artifact name points to a file.

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
