### PR TITLE
Don't wait for command output/error scanner to finish when printing it

### DIFF
--- a/internal/exec/exec_msg.go
+++ b/internal/exec/exec_msg.go
@@ -1,13 +1,11 @@
 package exec
 
 const (
-	execMsg                = `executing the "%s" command...`
-	execFileMsg            = `the executable file is at "%s"`
-	execFailed             = `could not execute the "%s" command`
-	execFailedOnStdoutMsg  = `could not get the "stdout" pipe`
-	execFailedOnStderrMsg  = `could not get the "stderr" pipe`
-	execFailedOnScanerrMsg = `could not read from the "stderr" pipe`
-	execFailedOnScanoutMsg = `could not read from the "stdout" pipe`
+	execMsg               = `executing the "%s" command...`
+	execFileMsg           = `the executable file is at "%s"`
+	execFailed            = `could not execute the "%s" command`
+	execFailedOnStdoutMsg = `could not get the "stdout" pipe`
+	execFailedOnStderrMsg = `could not get the "stderr" pipe`
 	// ExecInvalidTimeoutMsg is the error message that occurs when a timeout value is invalid
 	ExecInvalidTimeoutMsg = `invalid timeout value "%s", it should be in the form "[123h][123m][123s]"`
 	// ExecTimeoutMsg is the error message that occurs when a timeout is reached during commands execution


### PR DESCRIPTION
### Checklist
- [X] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
