### PR TITLE
test(docker): adapt expected version pattern

### DIFF
--- a/test/goss/goss.yaml
+++ b/test/goss/goss.yaml
@@ -37,7 +37,7 @@ command:
   node --version:
     exit-status: 0
     stdout:
-    - v12.13.0
+    - v12.13
   # verify NPM @sap-scope registry configuration
   npm config get @sap:registry:
     exit-status: 0

--- a/test/goss/goss.yaml
+++ b/test/goss/goss.yaml
@@ -27,7 +27,7 @@ command:
   mbt --version:
     exit-status: 0
     stdout:
-    - v1.0.4
+    - Cloud MTA Build Tool version 1.0.4
   # verify installed MAVEN VERSION
   mvn --version:
     exit-status: 0


### PR DESCRIPTION
## Description

Test still expected the old output. 

```sh
sut_1   | Command: mbt --version: stdout: patterns not found: [v1.0.4]
```

Test expected the minor version to be 0 instead of 1
```sh
sut_1   | Command: node --version: stdout: patterns not found: [v12.13.0]
```

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
