### PR TITLE
test(docker): add timeout to cope with npm loading duration

### DIFF
--- a/test/goss/goss.yaml
+++ b/test/goss/goss.yaml
@@ -50,5 +50,6 @@ command:
     - https://registry.npmjs.org/
   cd ~ && npm install @sap/cds:
     exit-status: 0
+    timeout: 30000
     stdout:
     - + @sap/cds@


### PR DESCRIPTION
## Description

The test was failing because sometimes the `npm install` command runs longer than 10 seconds.

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
