### PR TITLE
Set name on module when building for neo platform

### DIFF
--- a/integration/cloud_mta_build_tool_test.go
+++ b/integration/cloud_mta_build_tool_test.go
@@ -208,6 +208,8 @@ modules:
   - name: node-js_api
     properties:
       url: ${default-url}
+  parameters:
+    name: nodejs
 parameters:
   hcp-deployer-version: 1.1.0
 `))

--- a/internal/artifacts/meta.go
+++ b/internal/artifacts/meta.go
@@ -51,6 +51,9 @@ func generateMeta(loc *dir.Loc, targetArtifacts dir.ITargetArtifacts, deployment
 	}
 
 	removeUndeployedModules(m, platform)
+
+	setPlatformSpecificParameters(m, platform)
+
 	// Generate meta info dir with required content
 	err = genMetaInfo(loc, targetArtifacts, loc, deploymentDescriptor, platform, m, createMetaInf)
 	return err


### PR DESCRIPTION
Add "name" parameter on modules that don't have it set with the neo application name.
See note here on application names in neo:
https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/42575dcfcc784ec4aab6a23e9310a5fa.html

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
