### PR TITLE
Fix resource and requires path in MANIFEST.MF when file is in subfolder

### DIFF
--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -169,7 +169,7 @@ func getResourcesEntries(target dir.ITargetPath, resources []*mta.Resource, cont
 		}
 		resourceEntry := entry{
 			EntryName:   resource.Name,
-			EntryPath:   resourceRelativePath,
+			EntryPath:   filepath.ToSlash(resourceRelativePath),
 			ContentType: contentType,
 			EntryType:   resourceEntry,
 		}
@@ -181,13 +181,14 @@ func getResourcesEntries(target dir.ITargetPath, resources []*mta.Resource, cont
 func buildEntries(target dir.ITargetPath, module *mta.Module, requiredDependencies []mta.Requires, contentTypes *conttype.ContentTypes) ([]entry, error) {
 	result := make([]entry, 0)
 	for _, requiredDependency := range requiredDependencies {
-		contentType, err := getContentType(filepath.Join(target.GetTargetTmpDir(), requiredDependency.Parameters["path"].(string)), contentTypes)
+		depPath := requiredDependency.Parameters["path"].(string)
+		contentType, err := getContentType(filepath.Join(target.GetTargetTmpDir(), depPath), contentTypes)
 		if err != nil {
 			return nil, err
 		}
 		requiredDependencyEntry := entry{
 			EntryName:   module.Name + "/" + requiredDependency.Name,
-			EntryPath:   requiredDependency.Parameters["path"].(string),
+			EntryPath:   filepath.ToSlash(filepath.Clean(depPath)),
 			ContentType: contentType,
 			EntryType:   requiredEntry,
 		}

--- a/internal/artifacts/manifest_test.go
+++ b/internal/artifacts/manifest_test.go
@@ -135,6 +135,9 @@ var _ = Describe("manifest", func() {
 			createDirInTmpFolder("assembly-sample", "web")
 			createFileInTmpFolder("assembly-sample", "config-site-host.json")
 			createFileInTmpFolder("assembly-sample", "xs-security.json")
+			createDirInTmpFolder("assembly-sample", "inner")
+			createFileInTmpFolder("assembly-sample", "inner", "uaa.json")
+			createFileInTmpFolder("assembly-sample", "inner", "xs-security.json")
 			loc := dir.Loc{SourcePath: getTestPath("assembly-sample"), TargetPath: getResultPath(), Descriptor: "dep"}
 			mtaObj, err := loc.ParseFile()
 			Ω(err).Should(Succeed())
@@ -157,6 +160,9 @@ var _ = Describe("manifest", func() {
 			createDirInTmpFolder("assembly-sample", "META-INF")
 			createDirInTmpFolder("assembly-sample", "web")
 			createFileInTmpFolder("assembly-sample", "config-site-host.json")
+			createDirInTmpFolder("assembly-sample", "inner")
+			createFileInTmpFolder("assembly-sample", "inner", "uaa.json")
+			createFileInTmpFolder("assembly-sample", "inner", "xs-security.json")
 			loc := dir.Loc{SourcePath: getTestPath("assembly-sample"), TargetPath: getTestPath("result"), Descriptor: "dep"}
 			mtaObj, err := loc.ParseFile()
 			Ω(err).Should(Succeed())

--- a/internal/artifacts/testdata/assembly-sample/inner/uaa.json
+++ b/internal/artifacts/testdata/assembly-sample/inner/uaa.json
@@ -1,0 +1,56 @@
+{
+    "xsappname"     : "java-hello-world-i318495222",
+    "scopes"        : [
+                        {
+                          "name"                 : "$XSAPPNAME.Display",
+                           "description"         : "display"
+                        },
+                        {
+                          "name"                 : "$XSAPPNAME.Create",
+                          "description"          : "create"
+                        },
+                        {
+                          "name"                 : "$XSAPPNAME.Delete",
+                          "description"          : "delete"
+                        }
+                      ],
+    "attributes"    : [
+                        {
+                          "name"                 : "Country",
+                          "description"          : "Country",
+                          "valueType"            : "s"
+                        },
+                        {
+                          "name"                 : "CostCenter",
+                          "description"          : "CostCenter",
+                          "valueType"            : "s"
+
+                        }
+                      ],
+    "role-templates": [
+                        {
+                          "name"                 : "Viewer",
+                          "description"          : "View all books",
+                          "scope-references"     : [
+                                                     "$XSAPPNAME.Display",
+                                                     "$XSAPPNAME.Create",
+                                                     "$XSAPPNAME.Delete"
+                                                   ],
+                          "attribute-references" : [
+                                                     "Country"
+                                                   ]
+                        },
+                        {
+                          "name"                 : "Editor",
+                          "description"          : "Edit and Delete the books",
+                          "scope-references"     : [
+                                                     "$XSAPPNAME.Create",
+                                                     "$XSAPPNAME.Delete"
+                                                   ],
+                          "attribute-references" : [
+                                                     "Country",
+                                                     "CostCenter"
+                                                   ]
+                        }
+                      ]
+}

--- a/internal/artifacts/testdata/assembly-sample/inner/xs-security.json
+++ b/internal/artifacts/testdata/assembly-sample/inner/xs-security.json
@@ -1,0 +1,56 @@
+{
+    "xsappname"     : "java-hello-world-i318495222",
+    "scopes"        : [
+                        {
+                          "name"                 : "$XSAPPNAME.Display",
+                           "description"         : "display"
+                        },
+                        {
+                          "name"                 : "$XSAPPNAME.Create",
+                          "description"          : "create"
+                        },
+                        {
+                          "name"                 : "$XSAPPNAME.Delete",
+                          "description"          : "delete"
+                        }
+                      ],
+    "attributes"    : [
+                        {
+                          "name"                 : "Country",
+                          "description"          : "Country",
+                          "valueType"            : "s"
+                        },
+                        {
+                          "name"                 : "CostCenter",
+                          "description"          : "CostCenter",
+                          "valueType"            : "s"
+
+                        }
+                      ],
+    "role-templates": [
+                        {
+                          "name"                 : "Viewer",
+                          "description"          : "View all books",
+                          "scope-references"     : [
+                                                     "$XSAPPNAME.Display",
+                                                     "$XSAPPNAME.Create",
+                                                     "$XSAPPNAME.Delete"
+                                                   ],
+                          "attribute-references" : [
+                                                     "Country"
+                                                   ]
+                        },
+                        {
+                          "name"                 : "Editor",
+                          "description"          : "Edit and Delete the books",
+                          "scope-references"     : [
+                                                     "$XSAPPNAME.Create",
+                                                     "$XSAPPNAME.Delete"
+                                                   ],
+                          "attribute-references" : [
+                                                     "Country",
+                                                     "CostCenter"
+                                                   ]
+                        }
+                      ]
+}

--- a/internal/artifacts/testdata/assembly-sample/mtad.yaml
+++ b/internal/artifacts/testdata/assembly-sample/mtad.yaml
@@ -25,6 +25,8 @@ modules:
       JBP_CONFIG_RESOURCE_CONFIGURATION: "['tomee/webapps/ROOT/WEB-INF/resources.xml': {'service_name_for_DefaultDB' : 'java-hdi-container'}]"
     requires:
       - name: java-uaa
+        parameters:
+          path: ./inner/uaa.json
       - name: java-hdi-container
       - name: java-hello-world-db
       - name: java-site-host
@@ -39,6 +41,11 @@ resources:
     type: com.sap.xs.uaa-space
     parameters:
       path: xs-security.json
+
+  - name: java-uaa2
+    type: com.sap.xs.uaa-space
+    parameters:
+      path: ./inner/xs-security.json
 
   - name: java-site-host
     type: com.sap.portal.site-host

--- a/internal/artifacts/testdata/golden_assembly_manifest.mf
+++ b/internal/artifacts/testdata/golden_assembly_manifest.mf
@@ -5,15 +5,21 @@ Name: web/
 MTA-Module: java-hello-world
 Content-Type: text/directory
 
+Name: inner/uaa.json
+MTA-Requires: java-hello-world-backend/java-uaa
+Content-Type: application/json
+
 Name: config-site-host.json
 MTA-Requires: java-hello-world-backend/java-site-host
 Content-Type: application/json
-
 
 Name: xs-security.json
 MTA-Resource: java-uaa
 Content-Type: application/json
 
+Name: inner/xs-security.json
+MTA-Resource: java-uaa2
+Content-Type: application/json
 
 Name: META-INF/mtad.yaml
 Content-Type: text/plain


### PR DESCRIPTION
The paths should contain slashes (and not backslashes) regardless of the OS

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
