### PR TITLE
[Fix] Upgrade node version in tests

### DIFF
--- a/cmd/testdata/mta/node-js/package.json
+++ b/cmd/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }

--- a/integration/testdata/mta_assemble/node/package.json
+++ b/integration/testdata/mta_assemble/node/package.json
@@ -14,7 +14,7 @@
     "start": "node server.js"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }

--- a/integration/testdata/mta_demo/node-js/package.json
+++ b/integration/testdata/mta_demo/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }

--- a/integration/testdata/mta_demo/node/package.json
+++ b/integration/testdata/mta_demo/node/package.json
@@ -14,7 +14,7 @@
     "start": "node server.js"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }

--- a/internal/artifacts/testdata/mta/node-js/package.json
+++ b/internal/artifacts/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }

--- a/internal/exec/testdata/mta/node-js/package.json
+++ b/internal/exec/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "8.x"
+    "node": "12.x"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
Node 8 is no longer supported. This caused integration tests to fail.

Before submitting a pull request, please ensure the following:

### Checklist
- [X] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
