### PR TITLE
[Feature] Allow to use global (default) MBT in mbt build command

### DIFF
--- a/internal/artifacts/project.go
+++ b/internal/artifacts/project.go
@@ -25,7 +25,7 @@ const (
 )
 
 // ExecBuild - Execute MTA project build
-func ExecBuild(makefileTmp, source, target string, extensions []string, mode, mtar, platform string, strict bool, jobs int, outputSync bool, wdGetter func() (string, error), wdExec func([][]string, bool) error, useDefaultMbt bool) error {
+func ExecBuild(makefileTmp, source, target string, extensions []string, mode, mtar, platform string, strict bool, jobs int, outputSync bool, wdGetter func() (string, error), wdExec func([][]string, bool) error, useDefaultMbt bool, keepMakefile bool) error {
 	message, err := version.GetVersionMessage()
 	if err == nil {
 		logs.Logger.Info(message)
@@ -41,9 +41,12 @@ func ExecBuild(makefileTmp, source, target string, extensions []string, mode, mt
 	err = wdExec([][]string{cmdParams}, false)
 
 	// Remove temporary Makefile
-	removeError := os.Remove(filepath.Join(source, filepath.FromSlash(makefileTmp)))
-	if removeError != nil {
-		removeError = errors.Wrapf(removeError, removeFailedMsg, makefileTmp)
+	var removeError error = nil
+	if !keepMakefile {
+		removeError = os.Remove(filepath.Join(source, filepath.FromSlash(makefileTmp)))
+		if removeError != nil {
+			removeError = errors.Wrapf(removeError, removeFailedMsg, makefileTmp)
+		}
 	}
 
 	if err != nil {

--- a/internal/artifacts/project_test.go
+++ b/internal/artifacts/project_test.go
@@ -52,18 +52,26 @@ var _ = Describe("Project", func() {
 		})
 		AfterEach(func() {
 			Ω(os.RemoveAll(getTestPath("result"))).Should(Succeed())
+			Ω(os.RemoveAll(filepath.Join(getTestPath("mta_with_zipped_module"), "Makefile_tmp.mta"))).Should(Succeed())
 		})
 		It("Sanity", func() {
 			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), nil, "", "", "cf", true, 0, false, os.Getwd, func(strings [][]string, b bool) error {
 				return nil
-			}, true)
+			}, true, false)
 			Ω(err).Should(Succeed())
-			Ω(filepath.Join(getResultPath(), "Makefile_tmp.mta")).ShouldNot(BeAnExistingFile())
+			Ω(filepath.Join(getTestPath("mta_with_zipped_module"), "Makefile_tmp.mta")).ShouldNot(BeAnExistingFile())
+		})
+		It("Sanity - keep makefile", func() {
+			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), nil, "", "", "cf", true, 0, false, os.Getwd, func(strings [][]string, b bool) error {
+				return nil
+			}, true, true)
+			Ω(err).Should(Succeed())
+			Ω(filepath.Join(getTestPath("mta_with_zipped_module"), "Makefile_tmp.mta")).Should(BeAnExistingFile())
 		})
 		It("Wrong - no platform", func() {
 			err := ExecBuild("Makefile_tmp.mta", getTestPath("mta_with_zipped_module"), getResultPath(), nil, "", "", "", true, 0, false, os.Getwd, func(strings [][]string, b bool) error {
 				return fmt.Errorf("failure")
-			}, true)
+			}, true, false)
 			Ω(err).Should(HaveOccurred())
 		})
 		It("Wrong - ExecuteMake fails on wrong location", func() {
@@ -72,7 +80,7 @@ var _ = Describe("Project", func() {
 					return "", errors.New("wrong location")
 				}, func(strings [][]string, b bool) error {
 					return nil
-				}, true)
+				}, true, false)
 			Ω(err).Should(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
This is done by setting the environment variable MBT_USE_DEFAULT to "true".
Also add a "-k" option to keep the temporary makefile in mbt build for
debug purposes.

Please explain the changes you made.

Add a link to the design (if applicable).

### Checklist
- [X] Code compiles correctly
- [X] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Formatting and linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
