### PR TITLE
Remove deprecated sap registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN apt-get update && \
     ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm && \
     ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/ && \
     npm install --prefix /usr/local/ -g grunt-cli && \
-    # config NPM
-    npm config set @sap:registry https://npm.sap.com --global && \
     echo "[INFO] installing maven." && \
     # install ui5-cli temporay solution
      npm install --prefix /usr/local/ -g @ui5/cli && \

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ docker build -t devxci/mbtci .
 
 - Nodejs - 12.18.3
 
-- SAP registry (@sap:registry https://npm.sap.com) contained in global node configuration.
-
 - Maven - 3.6.3
 
 - Golang - 1.14.7

--- a/test/goss/goss.yaml
+++ b/test/goss/goss.yaml
@@ -38,11 +38,11 @@ command:
     exit-status: 0
     stdout:
       - v12.18.3
-  # verify NPM @sap-scope registry configuration
+  # verify NPM @sap-scope registry NOT configured
   npm config get @sap:registry:
     exit-status: 0
     stdout:
-      - https://npm.sap.com
+      - undefined
   # verify NPM registry configuration
   npm config get registry:
     exit-status: 0


### PR DESCRIPTION
## Description

All module versions were re-published to npmjs.org between June 10th and 12th see https://www.npmjs.com/search?q=%40sap

Add a link to the design (if applicable).

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [x] Relevant logs were added
- [x] Formatting and linting run locally successfully
- [x] All tests pass
- [ ] UA review
- [ ] Design is documented
- [x] Extended the README / documentation, if necessary
- [x] Open source is approved
