### PR TITLE
Cloud mta build tool docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 # Golang CircleCI 2.0 configuration
 version: 2.1
 jobs:
-
   build-node:
     docker:
       - image: cimg/node:lts
@@ -13,8 +12,7 @@ jobs:
 
   build:
     docker:
-      - image: cimg/go:1.16
-
+      - image: cimg/go:1.17
     environment:
     working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
     steps:
@@ -67,10 +65,22 @@ jobs:
           command: |
             pip3 install --user reuse
             ~/.local/bin/reuse lint
-            
-  release:
+
+  ghpages:
     docker:
-      - image: cimg/go:1.16
+      - image: squidfunk/mkdocs-material:4.3.1
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - run:
+          name: release to GitHub Pages
+          command: |
+            cd docs
+            mkdocs gh-deploy --config-file ../docs/mkdocs.yml --remote-branch gh-pages
+
+  release-to-github:
+    docker:
+      - image: cimg/go:1.17
     working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
     steps:
       - add_ssh_keys:
@@ -107,11 +117,15 @@ jobs:
             sed  -i "/\"version\":/s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./package.json
             sed  -i "/cli_version:/s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./configs/version.yaml
             sed  -i "s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./VERSION
+            sed  -i "/ARG MBT_VERSION=/ s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./Dockerfile_mbtci_java8
+            sed  -i "/ARG MBT_VERSION=/ s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./Dockerfile_mbtci_java11
+            sed  -i "/ARG MBT_VERSION=/ s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./Dockerfile_mbtci_java17
+            sed  -i "s/- ${CURR_MBT_VERSION}/- ${MBT_VERSION}/" ./test/goss/goss_template.yaml
             sed  -i "/- Cloud MTA Build Tool -/s/${CURR_MBT_VERSION}/${MBT_VERSION}/" ./README.md
             #Generate version file
             go generate -run "go run ./internal/buildtools/embed.go ./internal/buildtools/buildtools_msg.go -source=./configs/version.yaml -target=./internal/version/version_cfg.go -name=VersionConfig -package=version"
             #Add all updated files to commit
-            git add ./package.json ./configs/version.yaml ./VERSION ./internal/version/version_cfg.go ./README.md 
+            git add ./package.json ./configs/version.yaml ./VERSION ./internal/version/version_cfg.go ./Dockerfile_mbtci_java8 ./Dockerfile_mbtci_java11 ./Dockerfile_mbtci_java17 ./test/goss/goss_template.yaml ./README.md 
             git config user.email "${CLOUD_MTA_BOT_EMAIL}"
             git config user.name "${CLOUD_MTA_BOT_USER}"
             git commit --allow-empty -m "[skip ci] Bump version ${MBT_VERSION}"
@@ -127,8 +141,45 @@ jobs:
             git checkout master
             export GITHUB_TOKEN=${CLOUD_MTA_BOT_GITHUB_TOKEN}
             curl -sL https://git.io/goreleaser | bash
-            
-  publish:
+
+  publish-to-dockerhub:
+    docker:
+      - image: cimg/go:1.17
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.6
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: "build Java 17 & Node 16 image"
+          command: |
+              MBT_VERSION=$(cat ./VERSION)
+              sh $PWD/scripts/build_image 17 16.17.1 ${MBT_VERSION}
+      - run:
+          name: publish image
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 17  16.17.1  ${MBT_VERSION} "devxci"
+
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 17  16.17.1  ${MBT_VERSION} "ghcr.io/sap"
+
+  publish-to-npm:
     docker:
       - image: cimg/node:lts
     working_directory: ~/repo
@@ -145,6 +196,7 @@ jobs:
             git fetch
             git rebase
       - run:
+          # mbt is an unscoped package, do not need to add "--access public" option in npm publish cmd 
           name: publish to npm
           command: |
             echo "//registry.npmjs.org/:_authToken=$CLOUD_MTA_BOT_NPM_TOKEN" > .npmrc
@@ -156,67 +208,13 @@ jobs:
           name: remove dummy release tag
           command: |
             git push https://github.com/SAP/cloud-mta-build-tool.git --delete release
-            
-  ghpages:
-    docker:
-      - image: squidfunk/mkdocs-material:4.3.1
-    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
-    steps:
-      - checkout
-      - run:
-          name: release to GitHub Pages
-          command: |
-            cd docs
-            mkdocs gh-deploy --config-file ../docs/mkdocs.yml --remote-branch gh-pages
 
 workflows:
   version: 2
-  on_pr_build:
+  on_tag_build_release_publish:
     jobs:
       - build:
           filters:
-            branches:
-              ignore: master
-      - build-node:
-          filters:
-            branches:
-              ignore: master
-      - compliance:
-          filters:
-            branches:
-              ignore: master
-      - test:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: master
-
-  on_merge_build_test:
-    jobs:
-      - build:
-          filters:
-            branches:
-              only: master
-      - build-node:
-          filters:
-            branches:
-              ignore: master
-      - compliance:
-          filters:
-            branches:
-              only: master
-      - test:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-
-  on_tag_build_test_deploy:
-    jobs:
-      - build:
-          filters:  # required since `release` has tag filters AND requires `build`
             tags:
               only: /release/
             branches:
@@ -224,31 +222,39 @@ workflows:
       - test:
           requires:
             - build
-          filters:  # required since `release` has tag filters AND requires `test`
-            tags:
-              only: /release/
-            branches:
-              ignore: /.*/
-      - release:
-          requires:
-            - test
-          filters:  # job runs on tag 'release' for no branches
+          filters:
             tags:
               only: /release/
             branches:
               ignore: /.*/
       - ghpages:
           requires:
-            - test
-          filters:  # job runs on tag 'release' for no branches
+            - build
+          filters:
             tags:
               only: /release/
             branches:
               ignore: /.*/
-      - publish:
+      - release-to-github:
           requires:
-            - release
-          filters:  # job runs on tag 'release' for no branches
+            - build
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
+      - publish-to-dockerhub:
+          requires:
+            - release-to-github
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
+      - publish-to-npm:
+          requires:
+            - publish-to-dockerhub
+          filters:
             tags:
               only: /release/
             branches:

--- a/Dockerfile_mbtci_java11
+++ b/Dockerfile_mbtci_java11
@@ -1,0 +1,99 @@
+FROM sapmachine:11
+
+# Build time arguments
+ARG MTA_USER_HOME=/home/mta
+ARG MBT_VERSION=1.2.18
+ARG GO_VERSION=1.15.6
+# node version as found in https://nodejs.org/dist/ e.g: "v16.15.0"
+ARG NODE_VERSION=NODE_VERSION_TEMPLATE
+ARG MAVEN_VERSION=3.6.3
+
+# Environment variables
+ENV PYTHON /usr/bin/python3
+ENV M2_HOME=/opt/maven/apache-maven-${MAVEN_VERSION}
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD http://aia.pki.co.sap.com/aia/SAP%20Global%20Root%20CA.crt \
+    /etc/ssl/certs/SAP_Global_Root_CA.crt
+
+# Download required env tools
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+		ca-certificates \
+		git \
+		curl && \
+
+    # Change security level as the SAP npm repo doesnt support buster new security upgrade
+    # the default configuration for OpenSSL in Buster explicitly requires using more secure ciphers and protocols,
+    # and the server running at http://npm.sap.com/ is running software configured to only provide insecure, older ciphers.
+    # This causes SSL connections using OpenSSL from a Buster based installation to fail
+    # Should be remove once SAP npm repo will patch the security level
+    # see - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912759
+    sed -i -E 's/(CipherString\s*=\s*DEFAULT@SECLEVEL=)2/\11/' /etc/ssl/openssl.cnf && \
+
+# install node
+	NODE_HOME=/opt/nodejs; mkdir -p ${NODE_HOME} && \
+    curl --fail --silent --output - "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz" \
+     | tar -xzv -f - -C "${NODE_HOME}" && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/ && \
+    npm install --prefix /usr/local/ -g grunt-cli && \
+	
+# install ui5-cli temporay solution
+	npm install --prefix /usr/local/ -g @ui5/cli && \
+
+# installing Golang
+	curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
+
+# update maven home
+	M2_BASE="$(dirname ${M2_HOME})" && \
+    mkdir -p "${M2_BASE}" && \
+    curl --fail --silent --output - "https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+    | tar -xzvf - -C "${M2_BASE}" && \
+    ln -s "${M2_HOME}/bin/mvn" /usr/local/bin/mvn && \
+    chmod --recursive a+w "${M2_HOME}"/conf/* && \
+
+# Download MBT
+	curl -L "https://github.com/SAP/cloud-mta-build-tool/releases/download/v${MBT_VERSION}/cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz" | tar -zx -C /usr/local/bin && \
+    chown root:root /usr/local/bin/mbt && \ 
+
+# handle users permission
+	useradd --home-dir "${MTA_USER_HOME}" \
+            --create-home \
+            --shell /bin/bash \
+            --user-group \
+            --uid 1000 \
+            --comment 'Cloud MTA Build Tool' \
+            --password "$(echo weUseMta |openssl passwd -1 -stdin)" mta && \
+# allow anybody to write into the images HOME
+    chmod a+w "${MTA_USER_HOME}" && \
+
+# Install essential build tools and python, required for building db modules
+    apt-get install --yes --no-install-recommends \
+		build-essential \
+		python2.7 \
+        python3 && \
+
+# Install python 3.10
+    #apt-get install software-properties-common && \
+    #apt-get update && \
+    #add-apt-repository ppa:deadsnakes/ppa && \
+    #apt-get install python3.10 && \
+
+# remove build env tools
+    apt-get remove --purge --autoremove --yes \
+		curl && \
+
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:./node_modules/.bin HOME=${MTA_USER_HOME}
+WORKDIR /project
+USER mta

--- a/Dockerfile_mbtci_java17
+++ b/Dockerfile_mbtci_java17
@@ -1,0 +1,93 @@
+FROM sapmachine:17
+
+# Build time arguments
+ARG MTA_USER_HOME=/home/mta
+ARG MBT_VERSION=1.2.18
+ARG GO_VERSION=1.15.6
+# node version as found in https://nodejs.org/dist/ e.g: "v16.15.0"
+ARG NODE_VERSION=NODE_VERSION_TEMPLATE
+ARG MAVEN_VERSION=3.6.3
+
+# Environment variables
+ENV PYTHON /usr/bin/python3
+ENV M2_HOME=/opt/maven/apache-maven-${MAVEN_VERSION}
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD http://aia.pki.co.sap.com/aia/SAP%20Global%20Root%20CA.crt \
+    /etc/ssl/certs/SAP_Global_Root_CA.crt
+
+# Download required env tools
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+		ca-certificates \
+		git \
+		curl && \
+
+    # Change security level as the SAP npm repo doesnt support buster new security upgrade
+    # the default configuration for OpenSSL in Buster explicitly requires using more secure ciphers and protocols,
+    # and the server running at http://npm.sap.com/ is running software configured to only provide insecure, older ciphers.
+    # This causes SSL connections using OpenSSL from a Buster based installation to fail
+    # Should be remove once SAP npm repo will patch the security level
+    # see - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912759
+    sed -i -E 's/(CipherString\s*=\s*DEFAULT@SECLEVEL=)2/\11/' /etc/ssl/openssl.cnf && \
+
+# install node
+	NODE_HOME=/opt/nodejs; mkdir -p ${NODE_HOME} && \
+    curl --fail --silent --output - "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz" \
+     | tar -xzv -f - -C "${NODE_HOME}" && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/ && \
+    npm install --prefix /usr/local/ -g grunt-cli && \
+	
+# install ui5-cli temporay solution
+	npm install --prefix /usr/local/ -g @ui5/cli && \
+
+# installing Golang
+	curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
+
+# update maven home
+	M2_BASE="$(dirname ${M2_HOME})" && \
+    mkdir -p "${M2_BASE}" && \
+    curl --fail --silent --output - "https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+    | tar -xzvf - -C "${M2_BASE}" && \
+    ln -s "${M2_HOME}/bin/mvn" /usr/local/bin/mvn && \
+    chmod --recursive a+w "${M2_HOME}"/conf/* && \
+
+# Download MBT
+	curl -L "https://github.com/SAP/cloud-mta-build-tool/releases/download/v${MBT_VERSION}/cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz" | tar -zx -C /usr/local/bin && \
+    chown root:root /usr/local/bin/mbt && \ 
+
+# handle users permission
+	useradd --home-dir "${MTA_USER_HOME}" \
+            --create-home \
+            --shell /bin/bash \
+            --user-group \
+            --uid 1000 \
+            --comment 'Cloud MTA Build Tool' \
+            --password "$(echo weUseMta |openssl passwd -1 -stdin)" mta && \
+# allow anybody to write into the images HOME
+    chmod a+w "${MTA_USER_HOME}" && \
+
+# Install essential build tools and python, required for building db modules
+	apt-get install --yes --no-install-recommends \
+		build-essential \
+        python2.7 \
+		python3 && \
+		
+# remove build env tools
+    apt-get remove --purge --autoremove --yes \
+		curl && \
+
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:./node_modules/.bin HOME=${MTA_USER_HOME}
+WORKDIR /project
+USER mta

--- a/Dockerfile_mbtci_java8
+++ b/Dockerfile_mbtci_java8
@@ -1,0 +1,118 @@
+# On `22.04 LTS (Jammy Jellyfish)` the `apt-get` command fails
+# https://ubuntu.com/about/release-cycle
+FROM ubuntu:focal
+
+# Build time arguments
+ARG DEBIAN_FRONTEND=noninteractive
+ARG MTA_USER_HOME=/home/mta
+ARG MBT_VERSION=1.2.18
+ARG GO_VERSION=1.15.6
+# node version as found in https://nodejs.org/dist/ e.g: "v16.15.0"
+ARG NODE_VERSION=NODE_VERSION_TEMPLATE
+ARG MAVEN_VERSION=3.6.3
+# This is used to build the download URL
+# e.g: https://tools.hana.ondemand.com/additional/sapjvm-8.1.086-linux-x64.zip
+# note that sometimes old versions are removed and new patch versions are added
+# so this argument's value may need to be updated in the future
+# Also see JVM section here:
+# - https://tools.hana.ondemand.com/#cloud
+ARG JAVA_VERSION=8.1.086
+
+# Environment variables
+ENV JAVA_HOME /opt/jdk
+ENV MAVEN_HOME /usr/apache-maven-$MAVEN_VERSION
+ENV PATH $PATH:$MAVEN_HOME/bin:${JAVA_HOME}/bin
+ENV PYTHON /usr/bin/python3
+ENV M2_HOME=/opt/maven/apache-maven-${MAVEN_VERSION}
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD http://aia.pki.co.sap.com/aia/SAP%20Global%20Root%20CA.crt \
+    /etc/ssl/certs/SAP_Global_Root_CA.crt
+
+# Download required env tools
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+		ca-certificates \
+		git \
+		make \
+		curl \
+		wget \
+		unzip && \
+
+    # Change security level as the SAP npm repo doesnt support buster new security upgrade
+    # the default configuration for OpenSSL in Buster explicitly requires using more secure ciphers and protocols,
+    # and the server running at http://npm.sap.com/ is running software configured to only provide insecure, older ciphers.
+    # This causes SSL connections using OpenSSL from a Buster based installation to fail
+    # Should be remove once SAP npm repo will patch the security level
+    # see - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=912759
+    sed -i -E 's/(CipherString\s*=\s*DEFAULT@SECLEVEL=)2/\11/' /etc/ssl/openssl.cnf && \
+
+# install java
+	mkdir -p /opt && \
+    wget --no-check-certificate --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt; path=/;" -S https://tools.hana.ondemand.com/additional/sapjvm-${JAVA_VERSION}-linux-x64.zip && \
+    unzip sapjvm-${JAVA_VERSION}-linux-x64.zip -d /usr/local/ && \
+    ln -s /usr/local/sapjvm_8 /opt/jdk && \
+    rm sapjvm-${JAVA_VERSION}-linux-x64.zip && \
+
+# install node
+	NODE_HOME=/opt/nodejs; mkdir -p ${NODE_HOME} && \
+    curl --fail --silent --output - "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz" \
+     | tar -xzv -f - -C "${NODE_HOME}" && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm && \
+    ln -s "${NODE_HOME}/node-${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/ && \
+    npm install --prefix /usr/local/ -g grunt-cli && \
+	
+# install ui5-cli temporary solution
+	npm install --prefix /usr/local/ -g @ui5/cli && \
+
+# installing Golang
+	curl -O https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
+    mkdir -p ${GOPATH}/src ${GOPATH}/bin && \
+
+# update maven home
+	M2_BASE="$(dirname ${M2_HOME})" && \
+    mkdir -p "${M2_BASE}" && \
+    curl --fail --silent --output - "https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+    | tar -xzvf - -C "${M2_BASE}" && \
+    ln -s "${M2_HOME}/bin/mvn" /usr/local/bin/mvn && \
+    chmod --recursive a+w "${M2_HOME}"/conf/* && \
+
+# Download MBT
+	curl -L "https://github.com/SAP/cloud-mta-build-tool/releases/download/v${MBT_VERSION}/cloud-mta-build-tool_${MBT_VERSION}_Linux_amd64.tar.gz" | tar -zx -C /usr/local/bin && \
+    chown root:root /usr/local/bin/mbt && \ 
+
+# handle users permission
+	useradd --home-dir "${MTA_USER_HOME}" \
+            --create-home \
+            --shell /bin/bash \
+            --user-group \
+            --uid 1000 \
+            --comment 'Cloud MTA Build Tool' \
+            --password "$(echo weUseMta |openssl passwd -1 -stdin)" mta && \
+# allow anybody to write into the images HOME
+    chmod a+w "${MTA_USER_HOME}" && \
+
+# Install essential build tools and python, required for building db modules
+	apt-get install --yes --no-install-recommends \
+		build-essential \
+		python2.7 \
+        python3 && \
+
+# remove build env tools
+    apt-get remove --purge --autoremove --yes \
+		curl \
+		wget \
+		unzip && \
+
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$PATH:./node_modules/.bin HOME=${MTA_USER_HOME}
+WORKDIR /project
+USER mta

--- a/cmd/testdata/mta/node-js/package.json
+++ b/cmd/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,18 @@
+# CMD: docker-compose --file docker-compose.test.yml up --build
+version: '3'
+services:
+  goss:
+    image: aelsabbahy/goss
+    volumes:
+    - goss-executable:/goss
+    command: goss --version
+  sut:
+    build: .
+    depends_on:
+    - goss
+    volumes:
+    - .:/project
+    - goss-executable:/goss
+    command: /goss/goss --gossfile test/goss/goss.yaml validate --format documentation --color
+volumes:
+  goss-executable:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/SAP/cloud-mta v1.0.4
 	github.com/deckarep/golang-set v1.7.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/mattn/goveralls v0.0.11 // indirect
+	github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 // indirect
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7 h1:UvyT9uN+3r7yLEYSlJsbQGdsaB/a0DlgWP3pql6iwOc=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/goveralls v0.0.11 h1:eJXea6R6IFlL1QMKNMzDvvHv/hwGrnvyig4N+0+XiMM=
+github.com/mattn/goveralls v0.0.11/go.mod h1:gU8SyhNswsJKchEV93xRQxX6X3Ei4PJdQk/6ZHvrvRk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -165,6 +167,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 h1:8Q0qkMVC/MmWkpIdlvZgcv2o2jrlF6zqVOh7W5YHdMA=
+github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -244,6 +248,7 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJ
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -277,6 +282,8 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -294,6 +301,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -305,6 +313,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -328,7 +337,9 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220222200937-f2425489ef4c h1:sSIdNI2Dd6vGv47bKc/xArpfxVmEz2+3j0E6I484xC4=
 golang.org/x/sys v0.0.0-20220222200937-f2425489ef4c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -359,6 +370,8 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/integration/testdata/mta_assemble/node/package.json
+++ b/integration/testdata/mta_assemble/node/package.json
@@ -14,7 +14,7 @@
     "start": "node server.js"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/integration/testdata/mta_demo/node-js/package.json
+++ b/integration/testdata/mta_demo/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/integration/testdata/mta_demo/node/package.json
+++ b/integration/testdata/mta_demo/node/package.json
@@ -14,7 +14,7 @@
     "start": "node server.js"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/internal/artifacts/testdata/mta/node-js/package.json
+++ b/internal/artifacts/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/internal/exec/testdata/mta/node-js/package.json
+++ b/internal/exec/testdata/mta/node-js/package.json
@@ -18,7 +18,7 @@
     "test-coverage": "node ./node_modules/gulp/bin/gulp test-coverage"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.15.0"
   },
   "version": "1.0.0"
 }

--- a/scripts/build_image
+++ b/scripts/build_image
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# set readable variables
+export JAVA_VERSION_TEMPLATE="$1"
+export NODE_VERSION_TEMPLATE="$2"
+export MBT_VERSION="$3"
+
+# print java and node version parameter
+echo "Java version template: ${JAVA_VERSION_TEMPLATE}, Node version template: ${NODE_VERSION_TEMPLATE}"
+
+# validate java and node major version
+export JAVA_MAJOR_VERSION="${JAVA_VERSION_TEMPLATE}"
+export NODE_MAJOR_VERSION="$(echo ${NODE_VERSION_TEMPLATE} |awk -F. '{printf "%d", $1}')"
+
+echo "Java major version: ${JAVA_MAJOR_VERSION}, Node major version: ${NODE_MAJOR_VERSION}"
+
+if ([ "$JAVA_MAJOR_VERSION" -ne "8" ] && [ "$JAVA_MAJOR_VERSION" -ne "11" ] && [ "$JAVA_MAJOR_VERSION" -ne "17" ]) || \
+   ([ "$NODE_MAJOR_VERSION" -ne "14" ] && [ "$NODE_MAJOR_VERSION" -ne "16" ] && [ "$NODE_MAJOR_VERSION" -ne "18" ])
+then
+	echo "Java:${JAVA_MAJOR_VERSION}, Node:${NODE_MAJOR_VERSION} combination is not supported!"
+	exit -1
+fi
+
+# set jvm and node version and print
+export JAVA_VERSION="-java${JAVA_MAJOR_VERSION}"
+export NODE_VERSION="-node${NODE_MAJOR_VERSION}"
+echo "Java version: ${JAVA_VERSION}, Node version: ${NODE_VERSION}"
+
+# build docker image
+cp Dockerfile_mbtci_java${JAVA_MAJOR_VERSION} Dockerfile
+sed  -i "s/NODE_VERSION_TEMPLATE/v${NODE_VERSION_TEMPLATE}/" Dockerfile
+echo "Build mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION}"
+docker build -t mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION} .
+
+# test image
+if [ "$JAVA_MAJOR_VERSION" = "11" ] || [ "$JAVA_MAJOR_VERSION" = "8" ] || [ "$JAVA_MAJOR_VERSION" = "17" ]; then
+	cp test/goss/goss_template.yaml test/goss/goss.yaml
+	sed  -i "s/NODE_VERSION_TEMPLATE/v${NODE_VERSION_TEMPLATE}/" test/goss/goss.yaml
+	docker-compose -f ./docker-compose.test.yml up --build
+fi
+
+# cleanup
+rm -f Dockerfile
+rm -f test/goss/goss.yaml

--- a/scripts/publish_image
+++ b/scripts/publish_image
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# set readable variables
+export JAVA_VERSION_TEMPLATE="$1"
+export NODE_VERSION_TEMPLATE="$2"
+export MBT_VERSION="$3"
+export IMAGE_PREFIX="$4"
+
+# print java and node version parameter
+echo "Java version template: ${JAVA_VERSION_TEMPLATE}, Node version template: ${NODE_VERSION_TEMPLATE}"
+
+# validate java and node major version
+export JAVA_MAJOR_VERSION="${JAVA_VERSION_TEMPLATE}"
+export NODE_MAJOR_VERSION="$(echo ${NODE_VERSION_TEMPLATE} |awk -F. '{printf "%d", $1}')"
+
+echo "Java major version: ${JAVA_MAJOR_VERSION}, Node major version: ${NODE_MAJOR_VERSION}"
+
+if ([ "$JAVA_MAJOR_VERSION" -ne "8" ] && [ "$JAVA_MAJOR_VERSION" -ne "11" ] && [ "$JAVA_MAJOR_VERSION" -ne "17" ]) || \
+   ([ "$NODE_MAJOR_VERSION" -ne "14" ] && [ "$NODE_MAJOR_VERSION" -ne "16" ] && [ "$NODE_MAJOR_VERSION" -ne "18" ])
+then
+	echo "Java:${JAVA_MAJOR_VERSION}, Node:${NODE_MAJOR_VERSION} combination is not supported!"
+	exit -1
+fi
+
+# set jvm and node version and print
+export JAVA_VERSION="-java${JAVA_MAJOR_VERSION}"
+export NODE_VERSION="-node${NODE_MAJOR_VERSION}"
+echo "Java version: ${JAVA_VERSION}, Node version: ${NODE_VERSION}"
+
+# publish image
+echo "Publish mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION} to $DOCKER_REGISTRY"
+
+docker tag mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION} ${IMAGE_PREFIX}/mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION}
+docker push ${IMAGE_PREFIX}/mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION}
+docker tag mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION} ${IMAGE_PREFIX}/mbtci${JAVA_VERSION}${NODE_VERSION}:latest
+docker push ${IMAGE_PREFIX}/mbtci${JAVA_VERSION}${NODE_VERSION}:latest
+

--- a/test/goss/README.MD
+++ b/test/goss/README.MD
@@ -1,0 +1,44 @@
+# Testing the Container with DGOSS
+
+[GOSS](https://github.com/aelsabbahy/goss) is a *server validation tool* and together with [DGOSS](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) it can be used to validate Docker containers.
+
+## Execute the Tests
+
+1. Build the image in the project's root directory:
+
+```shell
+docker build -t devxci/mbtci .
+```
+
+2. Run `dgoss` command:
+
+```shell
+GOSS_FILES_PATH=./test/goss dgoss run --interactive --volume $PWD:/project devxci/mbtci
+```
+
+## Edit the Tests
+
+To edit the tests start the edit mode:
+
+```shell
+GOSS_FILES_PATH=./test/goss dgoss edit --interactive --volume $PWD:/project devxci/mbtci
+```
+
+Add further test cases, see `goss add --help` for further informations.
+
+## Execute the Tests with Docker-Compose
+
+The tests can also be executed with *docker-compose* which makes it obsolete to install GOSS/DGOSS.
+
+Execute the *docker-compose* file:
+
+```shell
+docker-compose --file docker-compose.test.yml up --build
+```
+
+The `--build` option forces the *image under test* to be rebuilt.
+
+## Docker Hub Autotest
+
+The Docker build on *Docker Hub* can automatically test the image that is built. This happend via a *docker-compose* file named `docker-compose.test.yml` that contains a *service* `sut`.
+Further informations can be found in [the official docs](https://docs.docker.com/docker-hub/builds/automated-testing/).

--- a/test/goss/goss_template.yaml
+++ b/test/goss/goss_template.yaml
@@ -1,0 +1,55 @@
+# GOSS Manual: https://github.com/aelsabbahy/goss/blob/master/docs/manual.md
+# CMD: GOSS_FILES_PATH=./test/goss dgoss run --interactive --volume $PWD:/project devxci/mbtci
+package:
+  git:
+    installed: true
+  python2.7:
+    installed: true
+  make:
+    installed: true
+user:
+  mta:
+    exists: true
+    uid: 1000
+    gid: 1000
+    groups:
+      - mta
+    home: /home/mta
+    shell: /bin/bash
+command:
+  # ensure that curl is not installed
+  curl --version:
+    exit-status: 127
+  # verify installed JAVA version
+  java -version:
+    exit-status: 0
+  # verify installed Cloud MTA Build Tool version
+  mbt --version:
+    exit-status: 0
+    stdout:
+      - 1.2.16
+  # verify installed MAVEN VERSION
+  mvn --version:
+    exit-status: 0
+    stdout:
+      - Apache Maven 3.6
+  # verify installed NODE version
+  node --version:
+    exit-status: 0
+    stdout:
+      - NODE_VERSION_TEMPLATE
+  # verify NPM @sap-scope registry NOT configured
+  npm config get @sap:registry:
+    exit-status: 0
+    stdout:
+      - undefined
+  # verify NPM registry configuration
+  npm config get registry:
+    exit-status: 0
+    stdout:
+      - https://registry.npmjs.org/
+  cd ~ && npm install @sap/cds:
+    exit-status: 0
+    timeout: 50000
+    stdout:
+      - + @sap/cds@


### PR DESCRIPTION
Before submitting a pull request, please ensure the following:

## Description

The feature is publish MBT to Dockerhub, npmjs and Github container.

For java version, it support java8, java11 and java 17

For node version, it support node14, node16 and node 18

For python version, it support python3 and python2.7

Notice, for this commit, we only generate java 17 & node 16 version, which to satisfy the new requirement from BAS team.

But the code include all java and node version combination, after we run the publish process without a problem, we will support rest java and node version combinations.

Doc info:

(1) Plan to support : https://wiki.one.int.sap/wiki/pages/viewpage.action?pageId=3138611365

(2) How to generate MTA Build Tool docker image: https://wiki.one.int.sap/wiki/display/LCNCBJ/How+to+generate+MTA+Build+Tool+docker+image

(3) [Cloud MBT Release Process](https://wiki.one.int.sap/wiki/display/webapptoolkit/Cloud+MBT+Release+Process)

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
