### PR TITLE
Fix grunt-cli missing install problem

### DIFF
--- a/Dockerfile_mbtci_template
+++ b/Dockerfile_mbtci_template
@@ -93,6 +93,14 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && node --version \
     && npm --version
 
+# Install Grunt CLI
+RUN set -ex \
+    && npm install --prefix /usr/local/ -g grunt-cli \
+    && npm cache clean -g --force \
+    # smoke test
+    && echo "grunt-cli install smoke test!" \
+    && grunt --version
+
 # Install UI5 CLI
 RUN set -ex \
     && npm install --prefix /usr/local/ -g @ui5/cli \

--- a/test/goss/goss_template.yaml
+++ b/test/goss/goss_template.yaml
@@ -11,8 +11,6 @@ package:
     installed: true
   make:
     installed: true
-  grunt:
-    installed: true
 user:
   mta:
     exists: true

--- a/test/goss/goss_template.yaml
+++ b/test/goss/goss_template.yaml
@@ -11,6 +11,8 @@ package:
     installed: true
   make:
     installed: true
+  grunt:
+    installed: true
 user:
   mta:
     exists: true


### PR DESCRIPTION
## Description
The grunt-cli is missing installed in Docker image in the commit which merge multiple docker files into one docker file

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [x] Relevant logs were added
- [x] Formatting and linting run locally successfully
- [x] All tests pass
- [x] UA review
- [x] Design is documented
- [x] Extended the README / documentation, if necessary
- [x] Open source is approved
