### PR TITLE
Add mtad.yaml schema version upgrade log in MBT build process

### DIFF
--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/SAP/cloud-mta/mta"
 
-	"github.com/SAP/cloud-mta-build-tool/internal/archive"
+	dir "github.com/SAP/cloud-mta-build-tool/internal/archive"
 	"github.com/SAP/cloud-mta-build-tool/internal/buildops"
 	"github.com/SAP/cloud-mta-build-tool/internal/logs"
 )
@@ -229,7 +229,12 @@ func adjustSchemaVersion(mtaStr *mta.MTA) error {
 		return err
 	}
 	if schemaVersion < 3 {
-		*mtaStr.SchemaVersion = "3.1"
+		oldSchemaVersion := *mtaStr.SchemaVersion
+		newSchemaVersion := "3.1"
+		logs.Logger.Infof("in mta.yaml, schema version %s is too lower; in generated MTA archive, schema version of mtad.yaml will be upgraded to %s",
+			oldSchemaVersion, newSchemaVersion)
+
+		*mtaStr.SchemaVersion = newSchemaVersion
 	}
 	return nil
 }

--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/SAP/cloud-mta/mta"
 
-	dir "github.com/SAP/cloud-mta-build-tool/internal/archive"
+	"github.com/SAP/cloud-mta-build-tool/internal/archive"
 	"github.com/SAP/cloud-mta-build-tool/internal/buildops"
 	"github.com/SAP/cloud-mta-build-tool/internal/logs"
 )

--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/SAP/cloud-mta/mta"
 
-	"github.com/SAP/cloud-mta-build-tool/internal/archive"
+	dir "github.com/SAP/cloud-mta-build-tool/internal/archive"
 	"github.com/SAP/cloud-mta-build-tool/internal/buildops"
 	"github.com/SAP/cloud-mta-build-tool/internal/logs"
 )
@@ -231,7 +231,7 @@ func adjustSchemaVersion(mtaStr *mta.MTA) error {
 	if schemaVersion < 3 {
 		oldSchemaVersion := *mtaStr.SchemaVersion
 		newSchemaVersion := "3.1"
-		logs.Logger.Infof("mta.yaml schema version %s is too lower; in generated MTA archive, schema version of mtad.yaml will be upgraded to %s",
+		logs.Logger.Infof("mta.yaml schema version %s is too low; in generated MTA archive, schema version of mtad.yaml will be increased to %s",
 			oldSchemaVersion, newSchemaVersion)
 
 		*mtaStr.SchemaVersion = newSchemaVersion

--- a/internal/artifacts/mtad.go
+++ b/internal/artifacts/mtad.go
@@ -231,7 +231,7 @@ func adjustSchemaVersion(mtaStr *mta.MTA) error {
 	if schemaVersion < 3 {
 		oldSchemaVersion := *mtaStr.SchemaVersion
 		newSchemaVersion := "3.1"
-		logs.Logger.Infof("in mta.yaml, schema version %s is too lower; in generated MTA archive, schema version of mtad.yaml will be upgraded to %s",
+		logs.Logger.Infof("mta.yaml schema version %s is too lower; in generated MTA archive, schema version of mtad.yaml will be upgraded to %s",
 			oldSchemaVersion, newSchemaVersion)
 
 		*mtaStr.SchemaVersion = newSchemaVersion


### PR DESCRIPTION
## Description

MBT build will increase schema version to 3.1 if it is less than 3 in the generated mtad.yaml, the code logic is added 4 years ago and hard code.

Now, customer will run into deployment failed if schema version in extension description(.mtaext file) is less than 3, the error message will be "Extension descriptors must have the same major schema version as the deployment descriptor".

This PR add schema version upgrade log in MBT build process to notice customer

### Checklist
- [x] Code compiles correctly
- [x] Relevant tests were added (unit / contract / integration)
- [x] Relevant logs were added
- [x] Formatting and linting run locally successfully
- [x] All tests pass
- [x] UA review
- [x] Design is documented
- [x] Extended the README / documentation, if necessary
- [x] Open source is approved
