### PR TITLE
Update MBT Test Case Timeout Configure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             go install github.com/mattn/goveralls
             go install github.com/modocache/gover
             go get golang.org/x/crypto/ssh/terminal
-      - run: go test -v ./... -coverprofile=mta.coverprofile
+      - run: go test -v ./... -coverprofile=mta.coverprofile -count=1 -timeout 30m
       - run: gover
       - run: goveralls -v -service=circle-ci -coverprofile=gover.coverprofile -repotoken $COVERALLS_TOKEN
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ tests:
 	 go test -v -count=1 -timeout 30m ./...
 # check code coverage
 cover:
-	go test -v -coverprofile cover.out ./...
+	go test -v -coverprofile cover.out ./... -count=1 -timeout 30m
 	go tool cover -html=cover.out -o cover.html
 	open cover.html
 


### PR DESCRIPTION
## Description

Adjust MBT Test Case timeout configuration to 30 min
### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
