### PR TITLE
Replace `--production` by `--omit=dev`

### DIFF
--- a/cmd/module_test.go
+++ b/cmd/module_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Commands", func() {
 		BeforeEach(func() {
 			config = make([]byte, len(commands.ModuleTypeConfig))
 			copy(config, commands.ModuleTypeConfig)
-			// Simplified commands configuration (performance purposes). removed "npm prune --production"
+			// Simplified commands configuration (performance purposes). removed "npm prune --omit=dev"
 			commands.ModuleTypeConfig = []byte(`
 builders:
 - name: html5

--- a/configs/builder_type_cfg.yaml
+++ b/configs/builder_type_cfg.yaml
@@ -16,13 +16,13 @@ builders:
     info: "installing module dependencies & remove dev dependencies"
     path: "path to config file which override the following default commands"
     commands:
-      - command: npm install --production
+      - command: npm install --omit=dev
 
   - name: npm-ci
     info: "clean install production dependencies"
     path: "path to config file which override the following default commands"
     commands:
-      - command: npm clean-install --production
+      - command: npm clean-install --omit=dev
 
   - name: grunt
     info: "execute grunt"
@@ -44,7 +44,7 @@ builders:
       - command: npm install
       - command: npm run init
       - command: npm run build
-      - command: npm prune --production
+      - command: npm prune --omit=dev
 
   - name: maven
     info: "build java application"

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -165,7 +165,7 @@ You can define your own build commands by configuring a `custom` builder as foll
       commands:
         - npm install
         - grunt
-        - npm prune --production
+        - npm prune --omit=dev
 
      
 ```

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -80,9 +80,9 @@ After renaming, make sure that the places where the name is used refer to the co
 </li>
 <li>
 
-The `hdb` builder is not supported by the Cloud MTA Build tool.  You no longer require builder settings for the `hdb` module because the required `npm install --production` command is run by default for this module type.
+The `hdb` builder is not supported by the Cloud MTA Build tool.  You no longer require builder settings for the `hdb` module because the required `npm install --omit=dev` command is run by default for this module type.
 
-If you used this builder for other module types, you can repace it with the `npm` builder or use the `custom` builder that runs the `"npm install --production"`command. 
+If you used this builder for other module types, you can replace it with the `npm` builder or use the `custom` builder that runs the `"npm install --omit=dev"`command.
 &nbsp;
 </li>
 &nbsp;

--- a/internal/artifacts/meta_test.go
+++ b/internal/artifacts/meta_test.go
@@ -104,7 +104,7 @@ modules:
 			BeforeEach(func() {
 				config = make([]byte, len(version.VersionConfig))
 				copy(config, version.VersionConfig)
-				// Simplified commands configuration (performance purposes). removed "npm prune --production"
+				// Simplified commands configuration (performance purposes). removed "npm prune --omit=dev"
 				version.VersionConfig = []byte(`
 cli_version:["x"]
 `)

--- a/internal/artifacts/module_arch_test.go
+++ b/internal/artifacts/module_arch_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ModuleArch", func() {
 	BeforeEach(func() {
 		config = make([]byte, len(commands.ModuleTypeConfig))
 		copy(config, commands.ModuleTypeConfig)
-		// Simplified commands configuration (performance purposes). removed "npm prune --production"
+		// Simplified commands configuration (performance purposes). removed "npm prune --omit=dev"
 		commands.ModuleTypeConfig = []byte(`
 builders:
 - name: html5

--- a/internal/artifacts/project_test.go
+++ b/internal/artifacts/project_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Project", func() {
 			cmds, err := getProjectBuilderCommands(projectBuild)
 			Ω(err).Should(Succeed())
 			Ω(len(cmds.Command)).Should(Equal(1))
-			Ω(cmds.Command[0]).Should(Equal("npm install --production"))
+			Ω(cmds.Command[0]).Should(Equal("npm install --omit=dev"))
 		})
 		It("Custom builder with no commands", func() {
 			projectBuild := mta.ProjectBuilder{

--- a/internal/buildtools/testdata/cfg.yaml
+++ b/internal/buildtools/testdata/cfg.yaml
@@ -5,7 +5,7 @@ builders:
   type:
   - command: npm install
   - command: grunt
-  - command: npm prune --production
+  - command: npm prune --omit=dev
 - name: java
   info: "build java application"
   path: "path to config file which override the following default commands"
@@ -15,7 +15,7 @@ builders:
   info: "build nodejs application"
   path: "path to config file which override the following default commands"
   type:
-  - command: npm install --production
+  - command: npm install --omit=dev
 - name: golang
   info: "build golang application"
   path: "path to config file which override the following default commands"

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -25,7 +25,7 @@ module-types:
     commands:
     - command: npm install 
     - command: grunt 
-    - command: npm prune --production
+    - command: npm prune --omit=dev
   - name: java
     info: "build java application"
     commands:
@@ -46,7 +46,7 @@ module-types:
 		}
 		var expected = CommandList{
 			Info:    "build UI application",
-			Command: []string{"npm install", "grunt", "npm prune --production"},
+			Command: []string{"npm install", "grunt", "npm prune --omit=dev"},
 		}
 		commands := ModuleTypes{}
 		customCommands := Builders{}
@@ -97,7 +97,7 @@ module-types:
     commands:
     - command: npm install
     - command: grunt
-    - command: npm prune --production
+    - command: npm prune --omit=dev
 `)
 		var modules = mta.Module{
 			Name: "uiapp",
@@ -132,7 +132,7 @@ module-types:
 	It("CommandProvider", func() {
 		expected := CommandList{
 			Info:    "installing module dependencies & remove dev dependencies",
-			Command: []string{"npm install --production"},
+			Command: []string{"npm install --omit=dev"},
 		}
 		Ω(CommandProvider(mta.Module{Type: "html5"})).Should(Equal(expected))
 	})
@@ -143,7 +143,7 @@ module-types:
 		BeforeEach(func() {
 			config = make([]byte, len(ModuleTypeConfig))
 			copy(config, ModuleTypeConfig)
-			// Simplified commands configuration (performance purposes). removed "npm prune --production"
+			// Simplified commands configuration (performance purposes). removed "npm prune --omit=dev"
 			ModuleTypeConfig = []byte(`
 module-types:
 - name: html5
@@ -175,7 +175,7 @@ module-types:
 		BeforeEach(func() {
 			moduleTypesConfig = make([]byte, len(ModuleTypeConfig))
 			copy(moduleTypesConfig, ModuleTypeConfig)
-			// Simplified commands configuration (performance purposes). removed "npm prune --production"
+			// Simplified commands configuration (performance purposes). removed "npm prune --omit=dev"
 			ModuleTypeConfig = []byte(`
 module-types:
 - name: html5
@@ -211,11 +211,11 @@ builders:
 	var _ = Describe("Command converter", func() {
 
 		It("Sanity", func() {
-			cmdInput := []string{"npm install {{config}}", "grunt", "npm prune --production"}
+			cmdInput := []string{"npm install {{config}}", "grunt", "npm prune --omit=dev"}
 			cmdExpected := [][]string{
 				{"path", "npm", "install", "{{config}}"},
 				{"path", "grunt"},
-				{"path", "npm", "prune", "--production"}}
+				{"path", "npm", "prune", "--omit=dev"}}
 			result, e := CmdConverter("path", cmdInput)
 			Ω(e).Should(Succeed())
 			Ω(result).Should(Equal(cmdExpected))
@@ -269,7 +269,7 @@ modules:
 			module, commands, _, err := moduleCmd(m, "htmlapp")
 			Ω(err).Should(Succeed())
 			Ω(module.Path).Should(Equal("app"))
-			Ω(commands).Should(Equal([]string{"npm install --production"}))
+			Ω(commands).Should(Equal([]string{"npm install --omit=dev"}))
 		})
 
 		It("Builder specified in build params", func() {
@@ -292,7 +292,7 @@ modules:
 			module, commands, _, err := moduleCmd(m, "htmlapp")
 			Ω(err).Should(BeNil())
 			Ω(module.Path).Should(Equal("app"))
-			Ω(commands).Should(Equal([]string{"npm install --production"}))
+			Ω(commands).Should(Equal([]string{"npm install --omit=dev"}))
 		})
 
 		It("Fetcher builder specified in build params", func() {
@@ -337,7 +337,7 @@ modules:
 				Ω(err).Should(Succeed())
 				Ω(module.Name).Should(Equal("node-js"))
 				Ω(len(cmd)).Should(Equal(1))
-				Ω(cmd[0]).Should(Equal("npm install --production"))
+				Ω(cmd[0]).Should(Equal("npm install --omit=dev"))
 
 			})
 			It("Invalid case - wrong module name", func() {

--- a/internal/commands/process_test.go
+++ b/internal/commands/process_test.go
@@ -16,7 +16,7 @@ builders:
     commands:
     - command: npm install
     - command: grunt
-    - command: npm prune --production
+    - command: npm prune --omit=dev
   - name: java
     info: "build java application"
     commands:
@@ -39,7 +39,7 @@ builders:
 				Commands: []Command{
 					{Command: "npm install"},
 					{Command: "grunt"},
-					{Command: "npm prune --production"},
+					{Command: "npm prune --omit=dev"},
 				},
 			},
 			{

--- a/internal/tpl/makefile_test.go
+++ b/internal/tpl/makefile_test.go
@@ -143,7 +143,7 @@ makefile_version: 0.0.0
 			Entry("module with no commands and with timeout",
 				"no_commands_with_timeout.yaml", "no_commands_with_timeout", `$(MBT) execute -d="$(PROJ_DIR)/no_commands_with_timeout" -t=3m`),
 			Entry("module with multiple commands",
-				"multiple_commands.yaml", "multiple_commands", `$(MBT) execute -d="$(PROJ_DIR)/multiple_commands" -c='npm install' -c=grunt -c='npm prune --production'`),
+				"multiple_commands.yaml", "multiple_commands", `$(MBT) execute -d="$(PROJ_DIR)/multiple_commands" -c='npm install' -c=grunt -c='npm prune --omit=dev'`),
 			Entry("module with command and timeout",
 				"command_with_timeout.yaml", "command_with_timeout", `$(MBT) execute -d="$(PROJ_DIR)/command_with_timeout" -t=2s -c='sleep 1'`),
 			Entry("module with commands with special characters",

--- a/internal/tpl/testdata/modulegen/dep_with_artifacts_and_targetpath.yaml
+++ b/internal/tpl/testdata/modulegen/dep_with_artifacts_and_targetpath.yaml
@@ -24,6 +24,6 @@ modules:
       builder: custom
       commands:
         - npm install
-        - npm prune --production
+        - npm prune --omit=dev
       timeout: 15m
       supported-platforms: []

--- a/internal/tpl/testdata/modulegen/multiple_commands.yaml
+++ b/internal/tpl/testdata/modulegen/multiple_commands.yaml
@@ -10,4 +10,4 @@ modules:
       commands:
         - npm install
         - grunt
-        - npm prune --production
+        - npm prune --omit=dev


### PR DESCRIPTION
## Description

This PR replaces all occurrences of `--production` in an `npm` context with `--omit=dev`.

Currently you get these warnings when deploying MTA projects with the standard `npm` builder:
"npm warn config production Use `--omit=dev` instead"

The [`omit`](https://docs.npmjs.com/cli/v8/commands/npm-install#omit) option was introduced with `npm` 8, so it's available in all supported versions.

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
