### PR TITLE
feat: add node 24 docker image support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -570,6 +570,38 @@ jobs:
             echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
             sh $PWD/scripts/publish_image 17.0.13 22.12.0 ${MBT_VERSION} "ghcr.io/sap"
 
+  publish-to-dockerhub-java17-node24:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 17.0.13 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 17.0.13 24.7.0 ${MBT_VERSION}
+      - run:
+          name: publish Java 17.0.13 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 17.0.13 24.7.0 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 17.0.13 24.7.0 ${MBT_VERSION} "ghcr.io/sap"
+
   publish-to-dockerhub-java19-node14:
     docker:
       - image: cimg/go:1.21
@@ -791,6 +823,37 @@ jobs:
             #Push to GitHub Container Registry
             echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
             sh $PWD/scripts/publish_image 21.0.4 22.12.0 ${MBT_VERSION} "ghcr.io/sap"
+  publish-to-dockerhub-java21-node24:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 21.0.4 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 21.0.4 24.7.0 ${MBT_VERSION}
+      - run:
+          name: publish Java 21.0.4 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 21.0.4 24.7.0 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 21.0.4 24.7.0 ${MBT_VERSION} "ghcr.io/sap"
   publish-to-dockerhub-java23-node18:
     docker:
       - image: cimg/go:1.21
@@ -886,6 +949,37 @@ jobs:
             #Push to GitHub Container Registry
             echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
             sh $PWD/scripts/publish_image 23.0.1 22.12.0 ${MBT_VERSION} "ghcr.io/sap"
+  publish-to-dockerhub-java23-node24:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 23.0.1 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 23.0.1 24.7.0 ${MBT_VERSION}
+      - run:
+          name: publish Java 23.0.1 & Node 24.7.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 23.0.1 24.7.0 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 23.0.1 24.7.0 ${MBT_VERSION} "ghcr.io/sap"
   remove-github-release-tag:
     docker:
       - image: cimg/go:1.21
@@ -1165,6 +1259,14 @@ workflows:
               only: /release/
             branches:
               ignore: /.*/
+      - publish-to-dockerhub-java17-node24:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
       - publish-to-dockerhub-java19-node14:
           requires:
             - publish-to-npm
@@ -1221,6 +1323,14 @@ workflows:
               only: /release/
             branches:
               ignore: /.*/
+      - publish-to-dockerhub-java21-node24:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
       - publish-to-dockerhub-java23-node18:
           requires:
             - publish-to-npm
@@ -1245,6 +1355,14 @@ workflows:
               only: /release/
             branches:
               ignore: /.*/
+      - publish-to-dockerhub-java23-node24:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
       - remove-github-release-tag:
           requires:
             - publish-to-dockerhub-java11-node14
@@ -1256,6 +1374,7 @@ workflows:
             - publish-to-dockerhub-java17-node18
             - publish-to-dockerhub-java17-node20
             - publish-to-dockerhub-java17-node22
+            - publish-to-dockerhub-java17-node24
             - publish-to-dockerhub-java19-node14
             - publish-to-dockerhub-java19-node16
             - publish-to-dockerhub-java19-node18
@@ -1263,9 +1382,11 @@ workflows:
             - publish-to-dockerhub-java21-node18
             - publish-to-dockerhub-java21-node20
             - publish-to-dockerhub-java21-node22
+            - publish-to-dockerhub-java21-node24
             - publish-to-dockerhub-java23-node18
             - publish-to-dockerhub-java23-node20
             - publish-to-dockerhub-java23-node22
+            - publish-to-dockerhub-java23-node24
           filters:
             tags:
               only: /release/

--- a/scripts/common_image
+++ b/scripts/common_image
@@ -12,7 +12,7 @@ export NODE_MAJOR_VERSION="$(echo ${NODE_VERSION_TEMPLATE}|awk -F. '{printf "%d"
 echo "Java major version: ${JAVA_MAJOR_VERSION}, Node major version: ${NODE_MAJOR_VERSION}"
 
 if ([ "$JAVA_MAJOR_VERSION" -ne "11" ] && [ "$JAVA_MAJOR_VERSION" -ne "17" ] && [ "$JAVA_MAJOR_VERSION" -ne "19" ] && [ "$JAVA_MAJOR_VERSION" -ne "21" ] && [ "$JAVA_MAJOR_VERSION" -ne "23" ]) || \
-   ([ "$NODE_MAJOR_VERSION" -ne "14" ] && [ "$NODE_MAJOR_VERSION" -ne "16" ] && [ "$NODE_MAJOR_VERSION" -ne "18" ] && [ "$NODE_MAJOR_VERSION" -ne "20" ] && [ "$NODE_MAJOR_VERSION" -ne "22" ])
+   ([ "$NODE_MAJOR_VERSION" -ne "14" ] && [ "$NODE_MAJOR_VERSION" -ne "16" ] && [ "$NODE_MAJOR_VERSION" -ne "18" ] && [ "$NODE_MAJOR_VERSION" -ne "20" ] && [ "$NODE_MAJOR_VERSION" -ne "22" ] && [ "$NODE_MAJOR_VERSION" -ne "24" ])
 then
 	echo "Java: ${JAVA_MAJOR_VERSION}, Node: ${NODE_MAJOR_VERSION} combination is not supported!"
 	exit -1


### PR DESCRIPTION
Add Docker build jobs for Node 24.7.0 with Java 17, 21, and 23 combinations following the same pattern as existing Node 22 support.

- Add publish-to-dockerhub-java17-node24 job
- Add publish-to-dockerhub-java21-node24 job
- Add publish-to-dockerhub-java23-node24 job
- Update scripts/common_image to validate Node major version 24
- Integrate new jobs into release workflow with proper dependencies

Existing GPG keys are sufficient for Node 24 release verification.

Before submitting a pull request, please ensure the following:

## Description

Please explain the changes you made.

Add a link to the design (if applicable).

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
