### PR TITLE
ci: add Docker image build jobs to master merge workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,6 +790,96 @@ workflows:
           filters:
             branches:
               only: master
+      - build-image:
+          name: build-image-java11-node20
+          java_version: "11.0.17"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java17-node20
+          java_version: "17.0.13"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java17-node22
+          java_version: "17.0.13"
+          node_version: "22.22.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java17-node24
+          java_version: "17.0.13"
+          node_version: "24.14.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java21-node20
+          java_version: "21.0.4"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java21-node22
+          java_version: "21.0.4"
+          node_version: "22.22.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java21-node24
+          java_version: "21.0.4"
+          node_version: "24.14.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java23-node20
+          java_version: "23.0.1"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java23-node22
+          java_version: "23.0.1"
+          node_version: "22.22.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java23-node24
+          java_version: "23.0.1"
+          node_version: "24.14.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - test:
           requires:
             - build


### PR DESCRIPTION
## Summary
- Add `build-image-*` parameterized job entries for all 10 Java/Node combinations (java11/17/21/23 × node20/22/24) to the `on_merge_build_test` workflow
- These were previously only in the `on_pr_build` workflow, meaning Docker image build failures after merge could go undetected until release time
- CircleCI builds the source branch HEAD (not the merge commit), so the PR build alone does not guarantee the merged result on master builds correctly

## Test plan
- [x] Verify CircleCI config is valid (no schema errors)
- [ ] Confirm `on_merge_build_test` workflow triggers all 10 `build-image-*` jobs on a master merge