### PR TITLE
feat: add Java 25 Docker image support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -998,6 +998,33 @@ workflows:
           filters:
             branches:
               only: master
+      - build-image:
+          name: build-image-java25-node20
+          java_version: "25.0.2"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java25-node22
+          java_version: "25.0.2"
+          node_version: "22.22.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - build-image:
+          name: build-image-java25-node24
+          java_version: "25.0.2"
+          node_version: "24.14.0"
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,6 +573,97 @@ jobs:
             #Push to GitHub Container Registry
             echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
             sh $PWD/scripts/publish_image 23.0.1 24.14.0 ${MBT_VERSION} "ghcr.io/sap"
+
+  publish-to-dockerhub-java25-node20:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 25.0.2 & Node 20.18.1 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 25.0.2 20.18.1 ${MBT_VERSION}
+      - run:
+          name: publish Java 25.0.2 & Node 20.18.1 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 20.18.1 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 20.18.1 ${MBT_VERSION} "ghcr.io/sap"
+  publish-to-dockerhub-java25-node22:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 25.0.2 & Node 22.22.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 25.0.2 22.22.0 ${MBT_VERSION}
+      - run:
+          name: publish Java 25.0.2 & Node 22.22.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 22.22.0 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 22.22.0 ${MBT_VERSION} "ghcr.io/sap"
+  publish-to-dockerhub-java25-node24:
+    docker:
+      - image: cimg/go:1.21
+    working_directory: ~/go/src/github.com/SAP/cloud-mta-build-tool
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: build image pre-setup
+          command: |
+            #Make sure HEAD points to master
+            git checkout master
+            git fetch
+            git rebase
+      - run:
+          name: build Java 25.0.2 & Node 24.14.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            sh $PWD/scripts/build_image 25.0.2 24.14.0 ${MBT_VERSION}
+      - run:
+          name: publish Java 25.0.2 & Node 24.14.0 image
+          command: |
+            MBT_VERSION=$(cat ./VERSION)
+            echo "Image release: ${MBT_VERSION}"
+            #Push to Docker Hub
+            echo "$DOCKER_HUB_TOKEN" | docker login --username $DOCKER_HUB_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 24.14.0 ${MBT_VERSION} "devxci"
+            #Push to GitHub Container Registry
+            echo "$CLOUD_MTA_BOT_GITHUB_TOKEN" | docker login "ghcr.io" --username $CLOUD_MTA_BOT_USER --password-stdin
+            sh $PWD/scripts/publish_image 25.0.2 24.14.0 ${MBT_VERSION} "ghcr.io/sap"
   remove-github-release-tag:
     docker:
       - image: cimg/go:1.21
@@ -750,6 +841,33 @@ workflows:
       - build-image:
           name: build-image-java23-node24
           java_version: "23.0.1"
+          node_version: "24.14.0"
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
+      - build-image:
+          name: build-image-java25-node20
+          java_version: "25.0.2"
+          node_version: "20.18.1"
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
+      - build-image:
+          name: build-image-java25-node22
+          java_version: "25.0.2"
+          node_version: "22.22.0"
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
+      - build-image:
+          name: build-image-java25-node24
+          java_version: "25.0.2"
           node_version: "24.14.0"
           requires:
             - build
@@ -1017,6 +1135,30 @@ workflows:
               only: /release/
             branches:
               ignore: /.*/
+      - publish-to-dockerhub-java25-node20:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
+      - publish-to-dockerhub-java25-node22:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
+      - publish-to-dockerhub-java25-node24:
+          requires:
+            - publish-to-npm
+          filters:
+            tags:
+              only: /release/
+            branches:
+              ignore: /.*/
       - remove-github-release-tag:
           requires:
             - publish-to-dockerhub-java11-node20
@@ -1029,6 +1171,9 @@ workflows:
             - publish-to-dockerhub-java23-node20
             - publish-to-dockerhub-java23-node22
             - publish-to-dockerhub-java23-node24
+            - publish-to-dockerhub-java25-node20
+            - publish-to-dockerhub-java25-node22
+            - publish-to-dockerhub-java25-node24
           filters:
             tags:
               only: /release/

--- a/scripts/build_image
+++ b/scripts/build_image
@@ -21,7 +21,8 @@ docker build -t mbtci${JAVA_VERSION}${NODE_VERSION}:${MBT_VERSION} .
 # test image
 if [ "$JAVA_MAJOR_VERSION" = "8" ] || [ "$JAVA_MAJOR_VERSION" = "11" ] || \ 
    [ "$JAVA_MAJOR_VERSION" = "17" ] || [ "$JAVA_MAJOR_VERSION" = "19" ] || \
-   [ "$JAVA_MAJOR_VERSION" = "21" ] || [ "$JAVA_MAJOR_VERSION" = "23" ]; then
+   [ "$JAVA_MAJOR_VERSION" = "21" ] || [ "$JAVA_MAJOR_VERSION" = "23" ] || \
+   [ "$JAVA_MAJOR_VERSION" = "25" ]; then
 	cp test/goss/goss_template.yaml test/goss/goss.yaml
 	sed_i "s/NODE_VERSION_TEMPLATE/${NODE_VERSION_TEMPLATE}/" test/goss/goss.yaml
 	sed_i "s/JAVA_VERSION_TEMPLATE/${JAVA_VERSION_TEMPLATE}/" test/goss/goss.yaml

--- a/scripts/common_image
+++ b/scripts/common_image
@@ -11,7 +11,7 @@ export NODE_MAJOR_VERSION="$(echo ${NODE_VERSION_TEMPLATE}|awk -F. '{printf "%d"
 
 echo "Java major version: ${JAVA_MAJOR_VERSION}, Node major version: ${NODE_MAJOR_VERSION}"
 
-if ([ "$JAVA_MAJOR_VERSION" -ne "11" ] && [ "$JAVA_MAJOR_VERSION" -ne "17" ] && [ "$JAVA_MAJOR_VERSION" -ne "19" ] && [ "$JAVA_MAJOR_VERSION" -ne "21" ] && [ "$JAVA_MAJOR_VERSION" -ne "23" ]) || \
+if ([ "$JAVA_MAJOR_VERSION" -ne "11" ] && [ "$JAVA_MAJOR_VERSION" -ne "17" ] && [ "$JAVA_MAJOR_VERSION" -ne "19" ] && [ "$JAVA_MAJOR_VERSION" -ne "21" ] && [ "$JAVA_MAJOR_VERSION" -ne "23" ] && [ "$JAVA_MAJOR_VERSION" -ne "25" ]) || \
    ([ "$NODE_MAJOR_VERSION" -ne "20" ] && [ "$NODE_MAJOR_VERSION" -ne "22" ] && [ "$NODE_MAJOR_VERSION" -ne "24" ])
 then
 	echo "Java: ${JAVA_MAJOR_VERSION}, Node: ${NODE_MAJOR_VERSION} combination is not supported!"


### PR DESCRIPTION
## Summary
- Add Docker image build and publish jobs for Java 25.0.2 with Node 20, 22, and 24
- Add Java 25 to the supported version validation in `scripts/common_image` and `scripts/build_image`
- Add `build-image-java25-*` entries to both `on_pr_build` and `on_merge_build_test` workflows
- Add `publish-to-dockerhub-java25-*` jobs to the release workflow

Based on #1216 by @joshuamitchell-revtrac — thank you for the contribution!

Closes #1184

## Test plan
- [ ] Verify CircleCI config is valid
- [ ] Confirm `build-image-java25-*` jobs run on PR builds
- [ ] Confirm `publish-to-dockerhub-java25-*` jobs are included in release workflow