### PR TITLE
fix: auto-resolve Maven version and fail fast on Docker build errors

### DIFF
--- a/Dockerfile_mbtci_template
+++ b/Dockerfile_mbtci_template
@@ -323,7 +323,7 @@ RUN set -ex \
   && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
   && apt-get remove --purge --autoremove -y ca-certificates curl gnupg dirmngr \
   # smoke test
-  && echo "mvn install smoke test!" \
+  && echo "mvn ${MAVEN_VERSION} install smoke test!" \
   && mvn --version
 
 # Install MBT

--- a/Dockerfile_mbtci_template
+++ b/Dockerfile_mbtci_template
@@ -6,10 +6,9 @@ ARG MTA_USER_HOME="/home/${MTA_USER}"
 ARG MBT_VERSION=1.2.46
 ARG GO_VERSION=1.26.0
 ARG NODE_VERSION=NODE_VERSION_TEMPLATE
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_MAJOR_MINOR=3.9
 ARG UI5_VERSION=4.0.26
 
-ARG MAVEN_BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 ARG SAPMACHINE_VERSION=JAVA_VERSION_TEMPLATE
 ARG CYCLONEDX_CLI_VERSION=0.27.1
 ARG CYCLONEDX_CLI_BINARY=cyclonedx
@@ -279,6 +278,12 @@ RUN set -ex \
   && apt-get update \
   && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
+  && MAVEN_VERSION=$(curl -fsSL https://downloads.apache.org/maven/maven-3/ \
+       | grep -oP '(?<=href=")'"${MAVEN_MAJOR_MINOR}"'\.[0-9]+' \
+       | sort -V | tail -1) \
+  && if [ -z "$MAVEN_VERSION" ]; then echo "ERROR: could not resolve Maven ${MAVEN_MAJOR_MINOR}.x version"; exit 1; fi \
+  && echo "Resolved Maven version: ${MAVEN_VERSION}" \
+  && MAVEN_BASE_URL="https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries" \
   && curl -fsSLO --compressed ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && curl -fsSLO --compressed ${MAVEN_BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
   && export GNUPGHOME="$(mktemp -d)" \
@@ -318,7 +323,7 @@ RUN set -ex \
   && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
   && apt-get remove --purge --autoremove -y ca-certificates curl gnupg dirmngr \
   # smoke test
-  && echo "mvn ${MAVEN_VERSION} install smoke test!" \
+  && echo "mvn install smoke test!" \
   && mvn --version
 
 # Install MBT

--- a/scripts/build_image
+++ b/scripts/build_image
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 # set readable variables
 export JAVA_VERSION_TEMPLATE="$1"

--- a/scripts/publish_image
+++ b/scripts/publish_image
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 # set readable variables
 export JAVA_VERSION_TEMPLATE="$1"


### PR DESCRIPTION
## Summary
- **Fix silent build failures**: Add `set -e` to `scripts/build_image` and `scripts/publish_image`. Previously, when `docker build` failed, the scripts continued to cleanup (`rm -f`), exited 0, and CI reported success. This is why `build-image-*` jobs showed Maven errors in logs but passed.
- **Auto-resolve Maven 3.9.x**: Replace hardcoded `MAVEN_VERSION=3.9.14` with build-time resolution of the latest 3.9.x patch from the Apache download mirror. The mirror only keeps the latest release, so hardcoded versions break on rotation.

## Test plan
- [ ] Verify `build-image-*` CI jobs pass with the auto-resolved Maven version
- [ ] Verify `build-image-*` CI jobs would now fail (not silently pass) if `docker build` errors occur