### PR TITLE
Fix duplicate items in generated CycloneDX SBOMs

### DIFF
--- a/internal/artifacts/sbom.go
+++ b/internal/artifacts/sbom.go
@@ -270,6 +270,9 @@ func updateSBomMetadataNode(mtaObj *mta.MTA, sbomTmpDir, sbomTmpName string) err
 	// set sbom timestamp
 	bom.Metadata.Timestamp = time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
+	// deduplicate components and dependencies to comply with CycloneDX uniqueItems schema requirement
+	deduplicateBOM(bom)
+
 	// write sbom to file system and ensure encoding of SBOM according to CycloneDX spec version 1.4
 	fileForWriting, err := os.OpenFile(sbomfilepath, os.O_RDWR, 0o644)
 	if err != nil {
@@ -417,6 +420,50 @@ func parseSBomFilePath(source string, sbomFilePath string) (string, string, stri
 	}
 
 	return sbomPath, sbomName, sbomType, sbomSuffix
+}
+
+// deduplicateBOM removes duplicate entries from components, dependencies, and dependsOn lists.
+// The cyclonedx merge tool does not deduplicate shared transitive dependencies across module SBOMs,
+// which would violate the CycloneDX schema's uniqueItems constraints.
+func deduplicateBOM(bom *cdx.BOM) {
+	if bom.Components != nil {
+		seen := make(map[string]struct{})
+		unique := make([]cdx.Component, 0, len(*bom.Components))
+		for _, c := range *bom.Components {
+			key := c.BOMRef
+			if key == "" {
+				key = c.PackageURL
+			}
+			if _, exists := seen[key]; !exists {
+				seen[key] = struct{}{}
+				unique = append(unique, c)
+			}
+		}
+		bom.Components = &unique
+	}
+
+	if bom.Dependencies != nil {
+		seenDeps := make(map[string]struct{})
+		unique := make([]cdx.Dependency, 0, len(*bom.Dependencies))
+		for _, dep := range *bom.Dependencies {
+			if _, exists := seenDeps[dep.Ref]; !exists {
+				seenDeps[dep.Ref] = struct{}{}
+				if dep.Dependencies != nil {
+					seenSubDeps := make(map[string]struct{})
+					uniqueSub := make([]string, 0, len(*dep.Dependencies))
+					for _, subRef := range *dep.Dependencies {
+						if _, exists := seenSubDeps[subRef]; !exists {
+							seenSubDeps[subRef] = struct{}{}
+							uniqueSub = append(uniqueSub, subRef)
+						}
+					}
+					dep.Dependencies = &uniqueSub
+				}
+				unique = append(unique, dep)
+			}
+		}
+		bom.Dependencies = &unique
+	}
 }
 
 func executeSBomCommand(sbomCmds [][]string) error {

--- a/internal/artifacts/sbom_test.go
+++ b/internal/artifacts/sbom_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	cdx "github.com/CycloneDX/cyclonedx-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -229,5 +230,128 @@ var _ = Describe("mbt build with sbom gen command", func() {
 		sbomFilePath := getTestPath("gen-sbom-result", "merged.bom.xml")
 		Ω(ExecuteProjectBuildeSBomGenerate(source, "", sbomFilePath, os.Getwd)).Should(HaveOccurred())
 		Ω(os.RemoveAll(tmpSrcFolder)).Should(Succeed())
+	})
+})
+
+var _ = Describe("deduplicateBOM", func() {
+	ptr := func(s []string) *[]string { return &s }
+	ptrComp := func(c []cdx.Component) *[]cdx.Component { return &c }
+	ptrDep := func(d []cdx.Dependency) *[]cdx.Dependency { return &d }
+
+	It("does nothing when BOM has no components or dependencies", func() {
+		bom := &cdx.BOM{}
+		deduplicateBOM(bom)
+		Ω(bom.Components).Should(BeNil())
+		Ω(bom.Dependencies).Should(BeNil())
+	})
+
+	It("keeps unique components unchanged", func() {
+		bom := &cdx.BOM{
+			Components: ptrComp([]cdx.Component{
+				{BOMRef: "pkg:npm/a@1.0.0"},
+				{BOMRef: "pkg:npm/b@2.0.0"},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Components).Should(HaveLen(2))
+	})
+
+	It("removes duplicate components with identical BOMRef", func() {
+		bom := &cdx.BOM{
+			Components: ptrComp([]cdx.Component{
+				{BOMRef: "pkg:npm/lodash@4.17.21"},
+				{BOMRef: "pkg:npm/lodash@4.17.21"},
+				{BOMRef: "pkg:npm/express@4.18.0"},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Components).Should(HaveLen(2))
+		Ω((*bom.Components)[0].BOMRef).Should(Equal("pkg:npm/lodash@4.17.21"))
+		Ω((*bom.Components)[1].BOMRef).Should(Equal("pkg:npm/express@4.18.0"))
+	})
+
+	It("removes duplicate components using PackageURL as fallback when BOMRef is empty", func() {
+		bom := &cdx.BOM{
+			Components: ptrComp([]cdx.Component{
+				{PackageURL: "pkg:npm/lodash@4.17.21"},
+				{PackageURL: "pkg:npm/lodash@4.17.21"},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Components).Should(HaveLen(1))
+	})
+
+	It("keeps unique dependencies unchanged", func() {
+		bom := &cdx.BOM{
+			Dependencies: ptrDep([]cdx.Dependency{
+				{Ref: "pkg:npm/a@1.0.0", Dependencies: ptr([]string{"pkg:npm/b@1.0.0"})},
+				{Ref: "pkg:npm/b@1.0.0", Dependencies: ptr([]string{})},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Dependencies).Should(HaveLen(2))
+	})
+
+	It("removes duplicate dependency entries", func() {
+		bom := &cdx.BOM{
+			Dependencies: ptrDep([]cdx.Dependency{
+				{Ref: "pkg:npm/lodash@4.17.21", Dependencies: ptr([]string{})},
+				{Ref: "pkg:npm/express@4.18.0", Dependencies: ptr([]string{})},
+				{Ref: "pkg:npm/lodash@4.17.21", Dependencies: ptr([]string{})},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Dependencies).Should(HaveLen(2))
+		Ω((*bom.Dependencies)[0].Ref).Should(Equal("pkg:npm/lodash@4.17.21"))
+		Ω((*bom.Dependencies)[1].Ref).Should(Equal("pkg:npm/express@4.18.0"))
+	})
+
+	It("removes duplicate entries within a dependsOn list", func() {
+		bom := &cdx.BOM{
+			Dependencies: ptrDep([]cdx.Dependency{
+				{
+					Ref: "pkg:npm/a@1.0.0",
+					Dependencies: ptr([]string{
+						"pkg:npm/lodash@4.17.21",
+						"pkg:npm/lodash@4.17.21",
+						"pkg:npm/express@4.18.0",
+					}),
+				},
+			}),
+		}
+		deduplicateBOM(bom)
+		deps := *bom.Dependencies
+		Ω(deps).Should(HaveLen(1))
+		Ω(*deps[0].Dependencies).Should(HaveLen(2))
+		Ω(*deps[0].Dependencies).Should(ContainElements("pkg:npm/lodash@4.17.21", "pkg:npm/express@4.18.0"))
+	})
+
+	It("handles nil dependsOn list within a dependency", func() {
+		bom := &cdx.BOM{
+			Dependencies: ptrDep([]cdx.Dependency{
+				{Ref: "pkg:npm/a@1.0.0", Dependencies: nil},
+			}),
+		}
+		Ω(func() { deduplicateBOM(bom) }).ShouldNot(Panic())
+		Ω((*bom.Dependencies)[0].Dependencies).Should(BeNil())
+	})
+
+	It("deduplicates both components and dependencies simultaneously", func() {
+		bom := &cdx.BOM{
+			Components: ptrComp([]cdx.Component{
+				{BOMRef: "pkg:npm/shared@1.0.0"},
+				{BOMRef: "pkg:npm/shared@1.0.0"},
+				{BOMRef: "pkg:npm/unique@2.0.0"},
+			}),
+			Dependencies: ptrDep([]cdx.Dependency{
+				{Ref: "pkg:npm/shared@1.0.0", Dependencies: ptr([]string{"pkg:npm/dep@1.0.0", "pkg:npm/dep@1.0.0"})},
+				{Ref: "pkg:npm/shared@1.0.0", Dependencies: ptr([]string{"pkg:npm/dep@1.0.0"})},
+				{Ref: "pkg:npm/unique@2.0.0", Dependencies: ptr([]string{})},
+			}),
+		}
+		deduplicateBOM(bom)
+		Ω(*bom.Components).Should(HaveLen(2))
+		Ω(*bom.Dependencies).Should(HaveLen(2))
+		Ω(*(*bom.Dependencies)[0].Dependencies).Should(HaveLen(1))
 	})
 })


### PR DESCRIPTION
Problem

The mbt sbom-gen command produces SBOMs that fail CycloneDX schema validation with uniqueItems violations:

Duplicate entries in components[]
Duplicate entries in dependencies[]
Duplicate entries in dependsOn[] lists
Root cause

The build process generates a separate SBOM per MTA module and then merges them using cyclonedx merge --hierarchical. This merge does not deduplicate shared transitive dependencies — if two modules depend on the same library, it appears multiple times in the merged output. A subsequent re-encode step (updateSBomMetadataNode) preserves these duplicates unchanged.

Fix

Added a deduplicateBOM function in internal/artifacts/sbom.go that is called inside updateSBomMetadataNode after decoding the merged BOM and before re-encoding it. It removes duplicate entries from: components[] — keyed by BOMRef (fallback: PackageURL) dependencies[] — keyed by Ref
dependsOn[] within each dependency entry
Testing

Run mbt sbom-gen on an MTA project with at least two modules sharing common npm or Maven dependencies and validate the output against the CycloneDX 1.4 schema.

Before submitting a pull request, please ensure the following:

## Description

Please explain the changes you made.

Add a link to the design (if applicable).

### Checklist
- [ ] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [ ] Formatting and linting run locally successfully
- [ ] All tests pass
- [ ] UA review
- [ ] Design is documented
- [ ] Extended the README / documentation, if necessary
- [ ] Open source is approved
